### PR TITLE
Add a rule to report accidental author lines

### DIFF
--- a/fixtures/AuthorLine/ignore_attributes.adoc
+++ b/fixtures/AuthorLine/ignore_attributes.adoc
@@ -1,0 +1,5 @@
+// A document with an attribute declaration:
+= Topic title
+:custom-attribute: Custom value
+
+A paragraph.

--- a/fixtures/AuthorLine/ignore_comments.adoc
+++ b/fixtures/AuthorLine/ignore_comments.adoc
@@ -1,0 +1,5 @@
+////
+A first paragraph recognized as an author line:
+= Topic title
+An author line.
+////

--- a/fixtures/AuthorLine/ignore_empty_line.adoc
+++ b/fixtures/AuthorLine/ignore_empty_line.adoc
@@ -1,0 +1,4 @@
+// A document without an author line:
+= Topic title
+
+A paragraph.

--- a/fixtures/AuthorLine/ignore_subsections.adoc
+++ b/fixtures/AuthorLine/ignore_subsections.adoc
@@ -1,0 +1,3 @@
+// A level 1 section without an empty line.
+== Topic title
+A paragraph.

--- a/fixtures/AuthorLine/report_author_line.adoc
+++ b/fixtures/AuthorLine/report_author_line.adoc
@@ -1,0 +1,7 @@
+// A first paragraph recognized as an author line:
+= Topic title
+An author line.
+
+// Only the document heading can have author lines:
+= Another title
+A paragraph.

--- a/fixtures/AuthorLine/report_comments.adoc
+++ b/fixtures/AuthorLine/report_comments.adoc
@@ -1,0 +1,7 @@
+// A first paragraph recognized as an author line:
+= Topic title
+// Line comments are ignored.
+////
+Block comments are ignored.
+////
+An author line.

--- a/fixtures/AuthorLine/vale.ini
+++ b/fixtures/AuthorLine/vale.ini
@@ -1,0 +1,5 @@
+StylesPath = ../../styles/
+MinAlertLevel = warning
+
+[*.adoc]
+AsciiDocDITA.AuthorLine = YES

--- a/styles/AsciiDocDITA/AuthorLine.yml
+++ b/styles/AsciiDocDITA/AuthorLine.yml
@@ -1,0 +1,54 @@
+# Report accidental author lines.
+---
+extends: script
+message: "Author lines are not supported for topics."
+level: warning
+scope: raw
+script: |
+  text              := import("text")
+  matches           := []
+
+  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_comment_block   := text.re_compile("^/{4,}\\s*$")
+  r_document_title  := text.re_compile("^=[ \\t]\\S.*$")
+  r_attribute       := text.re_compile("^:!?\\S[^:]*:")
+
+  document          := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  in_comment_block  := false
+  need_empty_line   := false
+  start             := 0
+  end               := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_document_title.match(line) {
+      if need_empty_line {
+        matches = append(matches, {begin: start, end: start + end - 1})
+        break
+      }
+      need_empty_line = true
+    } else if need_empty_line {
+      if r_attribute.match(line) {
+        continue
+      } else if text.trim_space(line) != "" {
+        matches = append(matches, {begin: start, end: start + end - 1})
+        break
+      }
+      need_empty_line = false
+    }
+  }

--- a/test/AuthorLine.bats
+++ b/test/AuthorLine.bats
@@ -1,0 +1,62 @@
+# Copyright (C) 2025 Jaromir Hradilek
+
+# MIT License
+#
+# Permission  is hereby granted,  free of charge,  to any person  obtaining
+# a copy of  this software  and associated documentation files  (the "Soft-
+# ware"),  to deal in the Software  without restriction,  including without
+# limitation the rights to use,  copy, modify, merge,  publish, distribute,
+# sublicense, and/or sell copies of the Software,  and to permit persons to
+# whom the Software is furnished to do so,  subject to the following condi-
+# tions:
+#
+# The above copyright notice  and this permission notice  shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS",  WITHOUT WARRANTY OF ANY KIND,  EXPRESS
+# OR IMPLIED,  INCLUDING BUT NOT LIMITED TO  THE WARRANTIES OF MERCHANTABI-
+# LITY,  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT
+# SHALL THE AUTHORS OR COPYRIGHT HOLDERS  BE LIABLE FOR ANY CLAIM,  DAMAGES
+# OR OTHER LIABILITY,  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM,  OUT OF OR IN CONNECTION WITH  THE SOFTWARE  OR  THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+load test_helper
+
+@test "Ignore attribute declarations" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_attributes.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore author lines inside of block comments" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_comments.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore documents without author lines" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_empty_line.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore level 1 sections" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_subsections.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Report author lines only once" {
+  run run_vale "$BATS_TEST_FILENAME" report_author_line.adoc
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 1 ]
+  [ "${lines[0]}" = "report_author_line.adoc:3:1:AsciiDocDITA.AuthorLine:Author lines are not supported for topics." ]
+}
+
+@test "Report author lines separated by comments" {
+  run run_vale "$BATS_TEST_FILENAME" report_comments.adoc
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 1 ]
+  [ "${lines[0]}" = "report_comments.adoc:7:1:AsciiDocDITA.AuthorLine:Author lines are not supported for topics." ]
+}


### PR DESCRIPTION
Fixes issue #3.

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
