### PR TITLE
Do not report nested block titles

### DIFF
--- a/fixtures/TaskTitle/ignore_nested_titles.adoc
+++ b/fixtures/TaskTitle/ignore_nested_titles.adoc
@@ -1,0 +1,16 @@
+// Identify the document as a procedure module:
+:_mod-docs-content-type: PROCEDURE
+
+= Topic title
+
+A paragraph.
+
+.Procedure
+
+. First step.
+. Second step.
++
+.Irrelevant title
+----
+Example code.
+----

--- a/fixtures/TaskTitle/ignore_trailing_spaces.adoc
+++ b/fixtures/TaskTitle/ignore_trailing_spaces.adoc
@@ -1,0 +1,16 @@
+// Identify the document as a procedure module:
+:_mod-docs-content-type: PROCEDURE
+
+= Topic title
+
+A paragraph.
+
+// A supported block title with trailing spaces:
+.Prerequisite    
+
+A paragraph.
+
+// A supported block title with trailing tabs:
+.Procedure				
+
+A paragraph.

--- a/styles/AsciiDocDITA/TaskTitle.yml
+++ b/styles/AsciiDocDITA/TaskTitle.yml
@@ -12,7 +12,7 @@ script: |
   r_comment_block   := text.re_compile("^/{4,}\\s*$")
   r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t](?i:procedure)")
   r_block_title     := text.re_compile("^\\.{1,2}[^ \\t.].*$")
-  r_supported_title := text.re_compile("^\\.{1,2}(?:Prerequisites?|Procedure|Verification|Results?|Troubleshooting|Troubleshooting steps?|Next steps?|Additional resources)$")
+  r_supported_title := text.re_compile("^\\.{1,2}(?:Prerequisites?|Procedure|Verification|Results?|Troubleshooting|Troubleshooting steps?|Next steps?|Additional resources)[ \\t]*$")
 
   document          := text.split(text.trim_suffix(scope, "\n"), "\n")
 

--- a/styles/AsciiDocDITA/TaskTitle.yml
+++ b/styles/AsciiDocDITA/TaskTitle.yml
@@ -11,6 +11,7 @@ script: |
   r_comment_line    := text.re_compile("^(//|//[^/].*)$")
   r_comment_block   := text.re_compile("^/{4,}\\s*$")
   r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t](?i:procedure)")
+  r_list_continue   := text.re_compile("^\\+[ \\t]*$")
   r_block_title     := text.re_compile("^\\.{1,2}[^ \\t.].*$")
   r_supported_title := text.re_compile("^\\.{1,2}(?:Prerequisites?|Procedure|Verification|Results?|Troubleshooting|Troubleshooting steps?|Next steps?|Additional resources)[ \\t]*$")
 
@@ -18,6 +19,7 @@ script: |
 
   in_comment_block  := false
   is_procedure      := false
+  is_list_continue  := false
   start             := 0
   end               := 0
   block_titles      := []
@@ -38,11 +40,20 @@ script: |
     if in_comment_block { continue }
     if r_comment_line.match(line) { continue }
 
+    if r_list_continue.match(line) {
+      is_list_continue = true
+      continue
+    }
+
     if r_content_type.match(line) {
       is_procedure = true
     } else if r_block_title.match(line) && ! r_supported_title.match(line) {
-      block_titles = append(block_titles, {begin: start, end: start + end - 1})
+      if ! is_list_continue {
+        block_titles = append(block_titles, {begin: start, end: start + end - 1})
+      }
     }
+
+    is_list_continue = false
   }
 
   if is_procedure && block_titles {

--- a/test/TaskTitle.bats
+++ b/test/TaskTitle.bats
@@ -59,6 +59,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore nested block titles" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_nested_titles.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Report block titles in procedures with deprecated _content-type" {
   run run_vale "$BATS_TEST_FILENAME" report_content_type.adoc
   [ "$status" -eq 0 ]

--- a/test/TaskTitle.bats
+++ b/test/TaskTitle.bats
@@ -47,6 +47,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore supported block titles with trailing spaces" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_trailing_spaces.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Ignore steps that have similar syntax to block titles" {
   run run_vale "$BATS_TEST_FILENAME" ignore_steps.adoc
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Fixes issue #22. In addition, fixes an error when supported titles were reported if they had trailing white space.

### Implementation checklist

- [ ] The new code has been tested with the latest available version of Vale
- [ ] The new code comes with the corresponding fixtures and test cases
- [ ] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [ ] The new code passes all tests (run `make test` in the project directory)
