### PR TITLE
Add a rule to report a missing content type definition

### DIFF
--- a/fixtures/ContentType/ignore_content_type.adoc
+++ b/fixtures/ContentType/ignore_content_type.adoc
@@ -1,0 +1,6 @@
+// A topic with a deprecated content type definition:
+:_content-type: PROCEDURE
+
+= Topic title
+
+A paragraph.

--- a/fixtures/ContentType/ignore_defined_type.adoc
+++ b/fixtures/ContentType/ignore_defined_type.adoc
@@ -1,0 +1,6 @@
+// A topic with a valid content type definition:
+:_mod-docs-content-type: PROCEDURE
+
+= Topic title
+
+A paragraph.

--- a/fixtures/ContentType/ignore_module_type.adoc
+++ b/fixtures/ContentType/ignore_module_type.adoc
@@ -1,0 +1,6 @@
+// A topic with a deprecated content type definition:
+:_module-type: PROCEDURE
+
+= Topic title
+
+A paragraph.

--- a/fixtures/ContentType/report_comments.adoc
+++ b/fixtures/ContentType/report_comments.adoc
@@ -1,0 +1,6 @@
+// A topic with the content type definition commented out:
+//:_mod-docs-content-type: PROCEDURE
+
+= Topic title
+
+A paragraph.

--- a/fixtures/ContentType/report_missing_type.adoc
+++ b/fixtures/ContentType/report_missing_type.adoc
@@ -1,0 +1,4 @@
+// A topic without the content type definition:
+= Topic title
+
+A paragraph.

--- a/fixtures/ContentType/report_missing_value.adoc
+++ b/fixtures/ContentType/report_missing_value.adoc
@@ -1,0 +1,6 @@
+// A topic with an invalid content type definition:
+:_mod-docs-content-type:
+
+= Topic title
+
+A paragraph.

--- a/fixtures/ContentType/vale.ini
+++ b/fixtures/ContentType/vale.ini
@@ -1,0 +1,5 @@
+StylesPath = ../../styles/
+MinAlertLevel = warning
+
+[*.adoc]
+AsciiDocDITA.ContentType = YES

--- a/styles/AsciiDocDITA/ContentType.yml
+++ b/styles/AsciiDocDITA/ContentType.yml
@@ -1,0 +1,8 @@
+# Report a missing content type definition.
+---
+extends: occurrence
+message: "The '_mod-docs-content-type' attribute definition is missing."
+level: warning
+scope: raw
+min: 1
+token: '^(?:.*[\n\r]|):_(?:mod-docs-content|content|module)-type:[ \t]+\S'

--- a/test/ContentType.bats
+++ b/test/ContentType.bats
@@ -1,0 +1,63 @@
+# Copyright (C) 2025 Jaromir Hradilek
+
+# MIT License
+#
+# Permission  is hereby granted,  free of charge,  to any person  obtaining
+# a copy of  this software  and associated documentation files  (the "Soft-
+# ware"),  to deal in the Software  without restriction,  including without
+# limitation the rights to use,  copy, modify, merge,  publish, distribute,
+# sublicense, and/or sell copies of the Software,  and to permit persons to
+# whom the Software is furnished to do so,  subject to the following condi-
+# tions:
+#
+# The above copyright notice  and this permission notice  shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS",  WITHOUT WARRANTY OF ANY KIND,  EXPRESS
+# OR IMPLIED,  INCLUDING BUT NOT LIMITED TO  THE WARRANTIES OF MERCHANTABI-
+# LITY,  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT
+# SHALL THE AUTHORS OR COPYRIGHT HOLDERS  BE LIABLE FOR ANY CLAIM,  DAMAGES
+# OR OTHER LIABILITY,  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM,  OUT OF OR IN CONNECTION WITH  THE SOFTWARE  OR  THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+load test_helper
+
+@test "Ignore files with deprecated _content-type" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_content_type.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore files with deprecated _module-type" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_module_type.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore files with _mod-docs-content-type" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_module_type.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Report files with _mod-docs-content-type in line comment" {
+  run run_vale "$BATS_TEST_FILENAME" report_comments.adoc
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 1 ]
+  [ "${lines[0]}" = "report_comments.adoc:1:1:AsciiDocDITA.ContentType:The '_mod-docs-content-type' attribute definition is missing." ]
+}
+
+@test "Report files with _mod-docs-content-type without value" {
+  run run_vale "$BATS_TEST_FILENAME" report_missing_value.adoc
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 1 ]
+  [ "${lines[0]}" = "report_missing_value.adoc:1:1:AsciiDocDITA.ContentType:The '_mod-docs-content-type' attribute definition is missing." ]
+}
+
+@test "Report files without _mod-docs-content-type" {
+  run run_vale "$BATS_TEST_FILENAME" report_missing_type.adoc
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 1 ]
+  [ "${lines[0]}" = "report_missing_type.adoc:1:1:AsciiDocDITA.ContentType:The '_mod-docs-content-type' attribute definition is missing." ]
+}


### PR DESCRIPTION
Fixes issue #20.

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
