### PR TITLE
Add a rule to report unsupported character entity references

### DIFF
--- a/fixtures/EntityReference/ignore_comments.adoc
+++ b/fixtures/EntityReference/ignore_comments.adoc
@@ -1,0 +1,11 @@
+// DITA does not support HTML character entity references:
+
+////
+* &hellip;
+* &middot;
+* ...
+////
+
+
+// &hellip;
+// &middot;

--- a/fixtures/EntityReference/ignore_numeric_references.adoc
+++ b/fixtures/EntityReference/ignore_numeric_references.adoc
@@ -1,0 +1,5 @@
+// XML supports numeric character references:
+
+* &#8230; (horizontal ellipsis)
+* &#183; (middle dot)
+* ...

--- a/fixtures/EntityReference/ignore_supported_entities.adoc
+++ b/fixtures/EntityReference/ignore_supported_entities.adoc
@@ -1,0 +1,7 @@
+// XML defines five standard entity references:
+
+* &amp;
+* &lt;
+* &gt;
+* &apos;
+* &quot;

--- a/fixtures/EntityReference/report_entity_references.adoc
+++ b/fixtures/EntityReference/report_entity_references.adoc
@@ -1,0 +1,5 @@
+// DITA does not support HTML character entity references:
+
+* &hellip;
+* &middot;
+* ...

--- a/fixtures/EntityReference/report_multiple_references.adoc
+++ b/fixtures/EntityReference/report_multiple_references.adoc
@@ -1,0 +1,3 @@
+// DITA does not support HTML character entity references:
+
+A &ldquo;character entity reference&rdquo; can appear multiple times on one line and can be _&lsaquo;mixed with other markup&rsaquo;_.

--- a/fixtures/EntityReference/vale.ini
+++ b/fixtures/EntityReference/vale.ini
@@ -1,0 +1,5 @@
+StylesPath = ../../styles/
+MinAlertLevel = warning
+
+[*.adoc]
+AsciiDocDITA.EntityReference = YES

--- a/styles/AsciiDocDITA/EntityReference.yml
+++ b/styles/AsciiDocDITA/EntityReference.yml
@@ -1,0 +1,43 @@
+# Report unsupported character entity references.
+---
+extends: script
+message: "HTML character entity references are not supported in DITA."
+level: error
+scope: raw
+script: |
+  text               := import("text")
+  matches            := []
+
+  r_comment_line     := text.re_compile("^(//|//[^/].*)$")
+  r_comment_block    := text.re_compile("^/{4,}\\s*$")
+  r_entity_reference := text.re_compile("&[a-zA-Z0-9]+;")
+  r_supported_entity := text.re_compile("&(?:amp|lt|gt|apos|quot);")
+
+  document           := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  in_comment_block   := false
+  start              := 0
+  end                := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    for i, entry in r_entity_reference.find(line, -1) {
+      if ! r_supported_entity.match(entry[0].text) {
+        matches = append(matches, {begin: start + entry[0].begin, end: start + entry[0].end - 1})
+      }
+    }
+  }

--- a/test/EntityReference.bats
+++ b/test/EntityReference.bats
@@ -1,0 +1,60 @@
+# Copyright (C) 2025 Jaromir Hradilek
+
+# MIT License
+#
+# Permission  is hereby granted,  free of charge,  to any person  obtaining
+# a copy of  this software  and associated documentation files  (the "Soft-
+# ware"),  to deal in the Software  without restriction,  including without
+# limitation the rights to use,  copy, modify, merge,  publish, distribute,
+# sublicense, and/or sell copies of the Software,  and to permit persons to
+# whom the Software is furnished to do so,  subject to the following condi-
+# tions:
+#
+# The above copyright notice  and this permission notice  shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS",  WITHOUT WARRANTY OF ANY KIND,  EXPRESS
+# OR IMPLIED,  INCLUDING BUT NOT LIMITED TO  THE WARRANTIES OF MERCHANTABI-
+# LITY,  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT
+# SHALL THE AUTHORS OR COPYRIGHT HOLDERS  BE LIABLE FOR ANY CLAIM,  DAMAGES
+# OR OTHER LIABILITY,  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM,  OUT OF OR IN CONNECTION WITH  THE SOFTWARE  OR  THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+load test_helper
+
+@test "Ignore character entity references inside of comments" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_comments.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore numeric character references" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_numeric_references.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore supported character entity references" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_supported_entities.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Report unsupported character entity references" {
+  run run_vale "$BATS_TEST_FILENAME" report_entity_references.adoc
+  [ "$status" -ne 0 ]
+  [ "${#lines[@]}" -eq 2 ]
+  [ "${lines[0]}" = "report_entity_references.adoc:3:3:AsciiDocDITA.EntityReference:HTML character entity references are not supported in DITA." ]
+  [ "${lines[1]}" = "report_entity_references.adoc:4:3:AsciiDocDITA.EntityReference:HTML character entity references are not supported in DITA." ]
+}
+
+@test "Report all character entity references on single line" {
+  run run_vale "$BATS_TEST_FILENAME" report_multiple_references.adoc
+  [ "$status" -ne 0 ]
+  [ "${#lines[@]}" -eq 4 ]
+  [ "${lines[0]}" = "report_multiple_references.adoc:3:3:AsciiDocDITA.EntityReference:HTML character entity references are not supported in DITA." ]
+  [ "${lines[1]}" = "report_multiple_references.adoc:3:36:AsciiDocDITA.EntityReference:HTML character entity references are not supported in DITA." ]
+  [ "${lines[2]}" = "report_multiple_references.adoc:3:94:AsciiDocDITA.EntityReference:HTML character entity references are not supported in DITA." ]
+  [ "${lines[3]}" = "report_multiple_references.adoc:3:125:AsciiDocDITA.EntityReference:HTML character entity references are not supported in DITA." ]
+}


### PR DESCRIPTION
Fixes issue #16.

I ended up using `script` because the `existence` check refused to properly report all entity references on a single line. I also suspect it had issues with ignoring word boundaries no matter what configuration I used.

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
