### PR TITLE
Add a rule to report hard line breaks

### DIFF
--- a/fixtures/LineBreak/ignore_comments.adoc
+++ b/fixtures/LineBreak/ignore_comments.adoc
@@ -1,0 +1,33 @@
+// A hard line break:
+//An example +
+//hard line break.
+
+// A hard line break:
+// +
+//line break.
+
+// A hard line break attribute:
+//:hardbreaks-option:
+//
+//An example
+//hard line break.
+
+// A hard line break using the options attribute:
+//[options="hardbreaks"]
+//An example
+//hard line break
+
+// A hard line break using the options attribute:
+//[options='hardbreaks']
+//An example
+//hard line break
+
+// A hard line break using the options attribute:
+//[options=hardbreaks]
+//An example
+//hard line break
+
+// A hard line break using the shorthand syntax:
+//[%hardbreaks]
+//An example
+//hard line break.

--- a/fixtures/LineBreak/report_line_break.adoc
+++ b/fixtures/LineBreak/report_line_break.adoc
@@ -1,0 +1,33 @@
+// A hard line break:
+An example +
+hard line break.
+
+// A hard line break:
+/ +
+line break.
+
+// A hard line break attribute:
+:hardbreaks-option:
+
+An example
+hard line break.
+
+// A hard line break using the options attribute:
+[options="hardbreaks"]
+An example
+hard line break
+
+// A hard line break using the options attribute:
+[options='hardbreaks']
+An example
+hard line break
+
+// A hard line break using the options attribute:
+[options=hardbreaks]
+An example
+hard line break
+
+// A hard line break using the shorthand syntax:
+[%hardbreaks]
+An example
+hard line break.

--- a/fixtures/LineBreak/vale.ini
+++ b/fixtures/LineBreak/vale.ini
@@ -1,0 +1,5 @@
+StylesPath = ../../styles/
+MinAlertLevel = warning
+
+[*.adoc]
+AsciiDocDITA.LineBreak = YES

--- a/styles/AsciiDocDITA/LineBreak.yml
+++ b/styles/AsciiDocDITA/LineBreak.yml
@@ -1,0 +1,14 @@
+# Report that hard line breaks ara not supported.
+---
+extends: existence
+message: "Hard line breaks are not supported in DITA."
+level: warning
+scope: raw
+nonword: true
+tokens:
+  - '^.* \+[ \t]*$'
+  - '^:hardbreaks-option:(?:|.*?)[ \t]*$'
+  - '^\[[^\]]*%hardbreaks[^\n\]]*?\]'
+  - '^\[[^\]]*options=hardbreaks\b[^\n\]]*?\]'
+  - '^\[[^\]]*options="[^"]*hardbreaks\b[^\n\]]*?\]'
+  - "^\\[[^\\]]*options='[^']*hardbreaks\\b[^\\n\\]]*?\\]"

--- a/styles/AsciiDocDITA/LineBreak.yml
+++ b/styles/AsciiDocDITA/LineBreak.yml
@@ -6,7 +6,8 @@ level: warning
 scope: raw
 nonword: true
 tokens:
-  - '^.* \+[ \t]*$'
+  - '^[^/]{2}.* \+[ \t]*$'
+  - '^. \+[ \t]*$'
   - '^:hardbreaks-option:(?:|.*?)[ \t]*$'
   - '^\[[^\]]*%hardbreaks[^\n\]]*?\]'
   - '^\[[^\]]*options=hardbreaks\b[^\n\]]*?\]'

--- a/test/LineBreak.bats
+++ b/test/LineBreak.bats
@@ -1,0 +1,43 @@
+# Copyright (C) 2025 Jaromir Hradilek
+
+# MIT License
+#
+# Permission  is hereby granted,  free of charge,  to any person  obtaining
+# a copy of  this software  and associated documentation files  (the "Soft-
+# ware"),  to deal in the Software  without restriction,  including without
+# limitation the rights to use,  copy, modify, merge,  publish, distribute,
+# sublicense, and/or sell copies of the Software,  and to permit persons to
+# whom the Software is furnished to do so,  subject to the following condi-
+# tions:
+#
+# The above copyright notice  and this permission notice  shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS",  WITHOUT WARRANTY OF ANY KIND,  EXPRESS
+# OR IMPLIED,  INCLUDING BUT NOT LIMITED TO  THE WARRANTIES OF MERCHANTABI-
+# LITY,  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT
+# SHALL THE AUTHORS OR COPYRIGHT HOLDERS  BE LIABLE FOR ANY CLAIM,  DAMAGES
+# OR OTHER LIABILITY,  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM,  OUT OF OR IN CONNECTION WITH  THE SOFTWARE  OR  THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+load test_helper
+
+@test "Ignore hard line breaks in single-line comments" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_comments.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Report valid hard line break variations" {
+  run run_vale "$BATS_TEST_FILENAME" report_line_break.adoc
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 7 ]
+  [ "${lines[0]}" = "report_line_break.adoc:2:1:AsciiDocDITA.LineBreak:Hard line breaks are not supported in DITA." ]
+  [ "${lines[1]}" = "report_line_break.adoc:6:1:AsciiDocDITA.LineBreak:Hard line breaks are not supported in DITA." ]
+  [ "${lines[2]}" = "report_line_break.adoc:10:1:AsciiDocDITA.LineBreak:Hard line breaks are not supported in DITA." ]
+  [ "${lines[3]}" = "report_line_break.adoc:16:1:AsciiDocDITA.LineBreak:Hard line breaks are not supported in DITA." ]
+  [ "${lines[4]}" = "report_line_break.adoc:21:1:AsciiDocDITA.LineBreak:Hard line breaks are not supported in DITA." ]
+  [ "${lines[5]}" = "report_line_break.adoc:26:1:AsciiDocDITA.LineBreak:Hard line breaks are not supported in DITA." ]
+  [ "${lines[6]}" = "report_line_break.adoc:31:1:AsciiDocDITA.LineBreak:Hard line breaks are not supported in DITA." ]
+}


### PR DESCRIPTION
Fixes issue #7.

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [ ] The new code passes all tests (run `make test` in the project directory)
