### PR TITLE
Add a vale rule to report discrete headings

### DIFF
--- a/fixtures/DiscreteHeading/ignore_comments.adoc
+++ b/fixtures/DiscreteHeading/ignore_comments.adoc
@@ -1,0 +1,11 @@
+// A basic discrete heading:
+//[discrete]
+//== A discreate heading
+//
+//A paragraph.
+
+// A discrete heading with additional parameters:
+//[discrete,id="boo"]
+//== A discreate heading
+//
+//A paragraph.

--- a/fixtures/DiscreteHeading/report_discrete_heading.adoc
+++ b/fixtures/DiscreteHeading/report_discrete_heading.adoc
@@ -1,0 +1,11 @@
+// A basic discrete heading:
+[discrete]
+== A discreate heading
+
+A paragraph.
+
+// A discrete heading with additional parameters:
+[discrete,id="boo"]
+== A discreate heading
+
+A paragraph.

--- a/fixtures/DiscreteHeading/vale.ini
+++ b/fixtures/DiscreteHeading/vale.ini
@@ -1,0 +1,5 @@
+StylesPath = ../../styles/
+MinAlertLevel = warning
+
+[*.adoc]
+AsciiDocDITA.DiscreteHeading = YES

--- a/styles/AsciiDocDITA/DiscreteHeading.yml
+++ b/styles/AsciiDocDITA/DiscreteHeading.yml
@@ -1,0 +1,9 @@
+# Report that discrete headings are not supported.
+---
+extends: existence
+message: "Discrete headings are not supported in DITA."
+level: warning
+scope: raw
+nonword: true
+tokens:
+  - '^\[discrete\b[^\n\]]*?\]'

--- a/test/DiscreteHeading.bats
+++ b/test/DiscreteHeading.bats
@@ -1,0 +1,38 @@
+# Copyright (C) 2025 Jaromir Hradilek
+
+# MIT License
+#
+# Permission  is hereby granted,  free of charge,  to any person  obtaining
+# a copy of  this software  and associated documentation files  (the "Soft-
+# ware"),  to deal in the Software  without restriction,  including without
+# limitation the rights to use,  copy, modify, merge,  publish, distribute,
+# sublicense, and/or sell copies of the Software,  and to permit persons to
+# whom the Software is furnished to do so,  subject to the following condi-
+# tions:
+#
+# The above copyright notice  and this permission notice  shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS",  WITHOUT WARRANTY OF ANY KIND,  EXPRESS
+# OR IMPLIED,  INCLUDING BUT NOT LIMITED TO  THE WARRANTIES OF MERCHANTABI-
+# LITY,  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT
+# SHALL THE AUTHORS OR COPYRIGHT HOLDERS  BE LIABLE FOR ANY CLAIM,  DAMAGES
+# OR OTHER LIABILITY,  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM,  OUT OF OR IN CONNECTION WITH  THE SOFTWARE  OR  THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+load test_helper
+
+@test "Ignore discrete headings in single-line comments" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_comments.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Report valid discrete heading variations" {
+  run run_vale "$BATS_TEST_FILENAME" report_discrete_heading.adoc
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 2 ]
+  [ "${lines[0]}" = "report_discrete_heading.adoc:2:1:AsciiDocDITA.DiscreteHeading:Discrete headings are not supported in DITA." ]
+  [ "${lines[1]}" = "report_discrete_heading.adoc:8:1:AsciiDocDITA.DiscreteHeading:Discrete headings are not supported in DITA." ]
+}


### PR DESCRIPTION
Fixes issue #5.

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
