### PR TITLE
Add a vale rule to report level 2, 3, 4, and 5 sections

### DIFF
--- a/fixtures/NestedSection/ignore_comments.adoc
+++ b/fixtures/NestedSection/ignore_comments.adoc
@@ -1,0 +1,2 @@
+// A level 2 section:
+//=== An unsupported section

--- a/fixtures/NestedSection/ignore_invalid_sections.adoc
+++ b/fixtures/NestedSection/ignore_invalid_sections.adoc
@@ -1,0 +1,2 @@
+// An invalid section:
+======= An invalid section title

--- a/fixtures/NestedSection/ignore_valid_sections.adoc
+++ b/fixtures/NestedSection/ignore_valid_sections.adoc
@@ -1,0 +1,5 @@
+// A level 0 section:
+= A valid section
+
+// A level 1 section:
+== A valid section

--- a/fixtures/NestedSection/report_nested_section.adoc
+++ b/fixtures/NestedSection/report_nested_section.adoc
@@ -1,0 +1,11 @@
+// A level 2 section:
+=== An unsupported section
+
+// A level 3 section:
+==== An unsupported section
+
+// A level 4 section:
+===== An unsupported section 
+
+// A level 5 section:
+====== An unsupported section

--- a/fixtures/NestedSection/vale.ini
+++ b/fixtures/NestedSection/vale.ini
@@ -1,0 +1,5 @@
+StylesPath = ../../styles/
+MinAlertLevel = warning
+
+[*.adoc]
+AsciiDocDITA.NestedSection = YES

--- a/styles/AsciiDocDITA/NestedSection.yml
+++ b/styles/AsciiDocDITA/NestedSection.yml
@@ -1,0 +1,9 @@
+# Report that level 2, 3, 4, and 5 sections are not supported.
+---
+extends: existence
+message: "Level 2, 3, 4, and 5 sections are not supported in DITA."
+level: warning
+scope: raw
+nonword: true
+tokens:
+  - '^={3,6}[ \t]\S.*$'

--- a/test/NestedSection.bats
+++ b/test/NestedSection.bats
@@ -1,0 +1,52 @@
+# Copyright (C) 2025 Jaromir Hradilek
+
+# MIT License
+#
+# Permission  is hereby granted,  free of charge,  to any person  obtaining
+# a copy of  this software  and associated documentation files  (the "Soft-
+# ware"),  to deal in the Software  without restriction,  including without
+# limitation the rights to use,  copy, modify, merge,  publish, distribute,
+# sublicense, and/or sell copies of the Software,  and to permit persons to
+# whom the Software is furnished to do so,  subject to the following condi-
+# tions:
+#
+# The above copyright notice  and this permission notice  shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS",  WITHOUT WARRANTY OF ANY KIND,  EXPRESS
+# OR IMPLIED,  INCLUDING BUT NOT LIMITED TO  THE WARRANTIES OF MERCHANTABI-
+# LITY,  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT
+# SHALL THE AUTHORS OR COPYRIGHT HOLDERS  BE LIABLE FOR ANY CLAIM,  DAMAGES
+# OR OTHER LIABILITY,  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM,  OUT OF OR IN CONNECTION WITH  THE SOFTWARE  OR  THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+load test_helper
+
+@test "Ignore unsupported sections in single-line comments" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_comments.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore invalid sections" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_invalid_sections.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore valid sections" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_valid_sections.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Report unsupported sections" {
+  run run_vale "$BATS_TEST_FILENAME" report_nested_section.adoc
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 4 ]
+  [ "${lines[0]}" = "report_nested_section.adoc:2:1:AsciiDocDITA.NestedSection:Level 2, 3, 4, and 5 sections are not supported in DITA." ]
+  [ "${lines[1]}" = "report_nested_section.adoc:5:1:AsciiDocDITA.NestedSection:Level 2, 3, 4, and 5 sections are not supported in DITA." ]
+  [ "${lines[2]}" = "report_nested_section.adoc:8:1:AsciiDocDITA.NestedSection:Level 2, 3, 4, and 5 sections are not supported in DITA." ]
+  [ "${lines[3]}" = "report_nested_section.adoc:11:1:AsciiDocDITA.NestedSection:Level 2, 3, 4, and 5 sections are not supported in DITA." ]
+}


### PR DESCRIPTION
Fixes issue #11.

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
