### PR TITLE
Add a rule to report non-link content in Additional resources.

### DIFF
--- a/fixtures/RelatedLinks/ignore_comments.adoc
+++ b/fixtures/RelatedLinks/ignore_comments.adoc
@@ -1,0 +1,4 @@
+// Invalid lines in additional resources:
+.Additional resources
+
+//* Invalid line.

--- a/fixtures/RelatedLinks/ignore_other_sections.adoc
+++ b/fixtures/RelatedLinks/ignore_other_sections.adoc
@@ -1,0 +1,18 @@
+// Valid content in other sections:
+= Topic title
+
+A paragraph.
+
+.Prerequisites
+
+* First item.
+* Second item.
+
+.Procedure
+
+. First step.
+. Second step.
+
+.Additional resources
+
+* https://example.com

--- a/fixtures/RelatedLinks/ignore_valid_lines.adoc
+++ b/fixtures/RelatedLinks/ignore_valid_lines.adoc
@@ -1,0 +1,20 @@
+// Valid links and cross references:
+.Additional resources
+
+* link:/absolute/path/to/file.ext[]
+* link:/absolute/path/to/file.ext[link text]
+* link:/absolute/path/to/file.ext#anchor[]
+* link:https://example.com[]
+* link:https://example.com[link text]
+* https://example.com
+* https://example.com/page.html
+* https://example.com/page.html#anchor
+* https://example.com[link text]
+* https://example.com/page.html[link text]
+* https://example.com/page.html#anchor[link text]
+* xref:reference-link[link text]
+* xref:reference-link#anchor[link text]
+* xref:file-name.ext[link text]
+* xref:file-name.ext#anchor[link text]
+* <<anchor>>
+* <<anchor,link text>>

--- a/fixtures/RelatedLinks/report_non_links.adoc
+++ b/fixtures/RelatedLinks/report_non_links.adoc
@@ -1,0 +1,7 @@
+// Invalid lines in additional resources:
+.Additional resources
+
+An invalid line.
+
+* An invalid line.
+* An invalid line with a valid link:https://example.com[link].

--- a/fixtures/RelatedLinks/report_valid_sections.adoc
+++ b/fixtures/RelatedLinks/report_valid_sections.adoc
@@ -1,0 +1,7 @@
+// Invalid lines in additional resources:
+== Additional resources
+
+An invalid line.
+
+* An invalid line.
+* An invalid line with a valid link:https://example.com[link].

--- a/fixtures/RelatedLinks/vale.ini
+++ b/fixtures/RelatedLinks/vale.ini
@@ -1,0 +1,5 @@
+StylesPath = ../../styles/
+MinAlertLevel = warning
+
+[*.adoc]
+AsciiDocDITA.RelatedLinks = YES

--- a/styles/AsciiDocDITA/RelatedLinks.yml
+++ b/styles/AsciiDocDITA/RelatedLinks.yml
@@ -15,7 +15,7 @@ script: |
   r_any_title       := text.re_compile("^(?:={2,}[ \\t]+|\\.{1,2})\\S.*$")
   r_add_resources   := text.re_compile("^(?:={2,}[ \\t]+|\\.{1,2})Additional resources[ \\t]*$")
   r_link_macro      := text.re_compile("^[ \\t]*[\\*-][ \\t]+(?:link|mailto):(?:|[^: \\t\\[][^: \\t\\[]*)\\[.*?\\][ \\t]*$")
-  r_inline_link     := text.re_compile("^[ \\t]*[\\*-][ \\t]+(?:|link:|<)(?:https?|file|ftp|irc)://[^ \\t\\[\\]]+\\[.*?\\]>?[ \\t]*$")
+  r_inline_link     := text.re_compile("^[ \\t]*[\\*-][ \\t]+(?:|link:|<)(?:|\\+\\+)(?:https?|file|ftp|irc)://[^ \\t\\[\\]]+(?:|\\+\\+)(?:|\\[.*?\\])>?[ \\t]*$")
   r_xref_macro      := text.re_compile("^[ \\t]*[\\*-][ \\t]+xref:[A-Za-z0-9/.:{].*?\\[.*?\\][ \\t]*$")
   r_inline_xref     := text.re_compile("^[ \\t]*[\\*-][ \\t]+<<[A-Za-z0-9/.:{].*?>>[ \\t]*$")
   r_attribute       := text.re_compile("^:!?\\S[^:]*:")

--- a/styles/AsciiDocDITA/RelatedLinks.yml
+++ b/styles/AsciiDocDITA/RelatedLinks.yml
@@ -1,0 +1,68 @@
+# Report text outside of links in additional resources.
+---
+extends: script
+message: "Content other than links cannot be mapped to DITA related-links."
+level: warning
+scope: raw
+script: |
+  text              := import("text")
+  matches           := []
+
+  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_comment_block   := text.re_compile("^/{4,}\\s*$")
+  r_document_title  := text.re_compile("^=[ \\t]\\S.*$")
+
+  r_any_title       := text.re_compile("^(?:={2,}[ \\t]+|\\.{1,2})\\S.*$")
+  r_add_resources   := text.re_compile("^(?:={2,}[ \\t]+|\\.{1,2})Additional resources[ \\t]*$")
+  r_link_macro      := text.re_compile("^[ \\t]*[\\*-][ \\t]+(?:link|mailto):(?:|[^: \\t\\[][^: \\t\\[]*)\\[.*?\\][ \\t]*$")
+  r_inline_link     := text.re_compile("^[ \\t]*[\\*-][ \\t]+(?:|link:|<)(?:https?|file|ftp|irc)://[^ \\t\\[\\]]+\\[.*?\\]>?[ \\t]*$")
+  r_xref_macro      := text.re_compile("^[ \\t]*[\\*-][ \\t]+xref:[A-Za-z0-9/.:{].*?\\[.*?\\][ \\t]*$")
+  r_inline_xref     := text.re_compile("^[ \\t]*[\\*-][ \\t]+<<[A-Za-z0-9/.:{].*?>>[ \\t]*$")
+  r_attribute       := text.re_compile("^:!?\\S[^:]*:")
+  r_empty_line      := text.re_compile("^[ \\t]*$")
+
+  document          := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  in_comment_block  := false
+  in_add_resources  := false
+  start             := 0
+  end               := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_empty_line.match(line) { continue }
+    if r_attribute.match(line) { continue }
+
+    if r_add_resources.match(line) {
+      in_add_resources = true
+      continue
+    }
+
+    if ! in_add_resources { continue }
+
+    if r_any_title.match(line) {
+      in_add_resources = false
+      continue
+    }
+
+    if r_link_macro.match(line) || r_inline_link.match(line) ||
+       r_xref_macro.match(line) || r_inline_xref.match(line) {
+      continue
+    }
+
+    matches = append(matches, {begin: start, end: start + end - 1})
+  }

--- a/test/RelatedLinks.bats
+++ b/test/RelatedLinks.bats
@@ -1,0 +1,60 @@
+# Copyright (C) 2025 Jaromir Hradilek
+
+# MIT License
+#
+# Permission  is hereby granted,  free of charge,  to any person  obtaining
+# a copy of  this software  and associated documentation files  (the "Soft-
+# ware"),  to deal in the Software  without restriction,  including without
+# limitation the rights to use,  copy, modify, merge,  publish, distribute,
+# sublicense, and/or sell copies of the Software,  and to permit persons to
+# whom the Software is furnished to do so,  subject to the following condi-
+# tions:
+#
+# The above copyright notice  and this permission notice  shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS",  WITHOUT WARRANTY OF ANY KIND,  EXPRESS
+# OR IMPLIED,  INCLUDING BUT NOT LIMITED TO  THE WARRANTIES OF MERCHANTABI-
+# LITY,  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT
+# SHALL THE AUTHORS OR COPYRIGHT HOLDERS  BE LIABLE FOR ANY CLAIM,  DAMAGES
+# OR OTHER LIABILITY,  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM,  OUT OF OR IN CONNECTION WITH  THE SOFTWARE  OR  THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+load test_helper
+
+@test "Ignore content inside of line and block comments" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_comments.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore content in other sections" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_other_sections.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore valid lines with all link variations" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_valid_lines.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Report content other than links in additional resources" {
+  run run_vale "$BATS_TEST_FILENAME" report_non_links.adoc
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 3 ]
+  [ "${lines[0]}" = "report_non_links.adoc:4:1:AsciiDocDITA.RelatedLinks:Content other than links cannot be mapped to DITA related-links." ]
+  [ "${lines[1]}" = "report_non_links.adoc:6:1:AsciiDocDITA.RelatedLinks:Content other than links cannot be mapped to DITA related-links." ]
+  [ "${lines[2]}" = "report_non_links.adoc:7:1:AsciiDocDITA.RelatedLinks:Content other than links cannot be mapped to DITA related-links." ]
+}
+
+@test "Recognize additional resources title variations" {
+  run run_vale "$BATS_TEST_FILENAME" report_valid_sections.adoc
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 3 ]
+  [ "${lines[0]}" = "report_valid_sections.adoc:4:1:AsciiDocDITA.RelatedLinks:Content other than links cannot be mapped to DITA related-links." ]
+  [ "${lines[1]}" = "report_valid_sections.adoc:6:1:AsciiDocDITA.RelatedLinks:Content other than links cannot be mapped to DITA related-links." ]
+  [ "${lines[2]}" = "report_valid_sections.adoc:7:1:AsciiDocDITA.RelatedLinks:Content other than links cannot be mapped to DITA related-links." ]
+}


### PR DESCRIPTION
Fixes issue #12.

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
