### PR TITLE
Add a rule to report non-step elements in procedures

### DIFF
--- a/fixtures/TaskStep/ignore_attribute_lists.adoc
+++ b/fixtures/TaskStep/ignore_attribute_lists.adoc
@@ -1,0 +1,11 @@
+// Valid content in other sections:
+:_mod-docs-content-type: PROCEDURE
+
+.Procedure
+
+. A valid step.
+
+[role="_additional-resources"]
+.Additional resources
+
+A paragraph.

--- a/fixtures/TaskStep/ignore_comments.adoc
+++ b/fixtures/TaskStep/ignore_comments.adoc
@@ -1,0 +1,14 @@
+// Invalid lines in a procedure:
+:_mod-docs-content-type: PROCEDURE
+
+.Procedure
+
+// An invalid line.
+
+. A valid step.
+
+////
+An invalid line.
+////
+
+. A valid step.

--- a/fixtures/TaskStep/ignore_other_sections.adoc
+++ b/fixtures/TaskStep/ignore_other_sections.adoc
@@ -1,0 +1,19 @@
+// Valid content in other sections:
+:_mod-docs-content-type: PROCEDURE
+
+= Topic title
+
+A paragraph.
+
+.Prerequisites
+
+A paragraph.
+
+.Procedure
+
+. First step.
+. Second step.
+
+.Additional resources
+
+A paragraph.

--- a/fixtures/TaskStep/ignore_valid_lines.adoc
+++ b/fixtures/TaskStep/ignore_valid_lines.adoc
@@ -1,0 +1,24 @@
+// Valid lines in a procedure:
+:_mod-docs-content-type: PROCEDURE
+
+.Procedure
+
+. A valid step.
+A continued paragraph.
+
+. A valid step.
++
+A continued step.
+
+. A valid step.
++
+[source,asciidoc]
+----
+. A false step.
+
+A false paragraph.
+----
+
+. A valid step.
+
+.. A valid substep.

--- a/fixtures/TaskStep/report_non_steps.adoc
+++ b/fixtures/TaskStep/report_non_steps.adoc
@@ -1,0 +1,12 @@
+// Invalid lines in a procedure:
+:_mod-docs-content-type: PROCEDURE
+
+.Procedure
+
+An invalid line.
+
+. A valid step.
+
+An invalid line.
+
+. A valid step.

--- a/fixtures/TaskStep/vale.ini
+++ b/fixtures/TaskStep/vale.ini
@@ -1,0 +1,5 @@
+StylesPath = ../../styles/
+MinAlertLevel = warning
+
+[*.adoc]
+AsciiDocDITA.TaskStep = YES

--- a/styles/AsciiDocDITA/TaskStep.yml
+++ b/styles/AsciiDocDITA/TaskStep.yml
@@ -1,0 +1,105 @@
+# Report content other than steps in procedures.
+---
+extends: script
+message: "Content other than a single list cannot be mapped to DITA tasks."
+level: warning
+scope: raw
+script: |
+  text              := import("text")
+  matches           := []
+
+  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_comment_block   := text.re_compile("^/{4,}\\s*$")
+  r_other_block     := text.re_compile("^(?:\\.{4,}|-{4,}|={4,}|-{2})[ \\t]*$")
+  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t](?i:procedure)")
+  r_any_title       := text.re_compile("^(?:={2,}[ \\t]+|\\.{1,2})[^ \\t.].*$")
+  r_procedure       := text.re_compile("^(?:={2,}[ \\t]+|\\.{1,2})Procedure[ \\t]*$")
+  r_step            := text.re_compile("^[ \\t]*[\\*-.]+[ \\t]+\\S.*$")
+  r_attribute       := text.re_compile("^:!?\\S[^:]*:")
+  r_empty_line      := text.re_compile("^[ \\t]*$")
+  r_list_continue   := text.re_compile("^\\+[ \\t]*$")
+
+  document          := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  is_procedure_mod  := false
+  in_comment_block  := false
+  in_other_block    := false
+  in_procedure      := false
+  in_list           := false
+  in_step           := false
+  start             := 0
+  end               := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_content_type.match(line) {
+      is_procedure_mod = true
+      continue
+    }
+
+    if r_attribute.match(line) { continue }
+    if r_list_continue.match(line) { continue }
+
+    if r_procedure.match(line) {
+      in_procedure = true
+      continue
+    }
+
+    if ! in_procedure { continue }
+
+    if r_any_title.match(line) {
+      break
+    }
+
+    if in_step {
+      if r_other_block.match(line) {
+        delimiter := text.trim_space(line)
+        if ! in_other_block {
+          in_other_block = delimiter
+        } else if in_other_block == delimiter {
+          in_other_block = false
+        }
+        continue
+      }
+      if in_other_block { continue }
+    }
+
+    if r_empty_line.match(line) {
+      if in_step {
+        in_step = false
+      }
+      continue
+    }
+
+    if r_step.match(line) {
+      if ! in_list {
+        in_list = true
+      }
+      in_step = true
+      continue
+    }
+
+    if in_step { continue }
+
+    matches = append(matches, {begin: start, end: start + end - 1})
+
+    if in_list { break }
+  }
+
+  if ! is_procedure_mod {
+    matches = []
+  }

--- a/styles/AsciiDocDITA/TaskStep.yml
+++ b/styles/AsciiDocDITA/TaskStep.yml
@@ -16,6 +16,7 @@ script: |
   r_procedure       := text.re_compile("^(?:={2,}[ \\t]+|\\.{1,2})Procedure[ \\t]*$")
   r_step            := text.re_compile("^[ \\t]*[\\*-.]+[ \\t]+\\S.*$")
   r_attribute       := text.re_compile("^:!?\\S[^:]*:")
+  r_attribute_list  := text.re_compile("^\\[(?:|[\\w.#%{,\"'].*)\\][ \\t]*$")
   r_empty_line      := text.re_compile("^[ \\t]*$")
   r_list_continue   := text.re_compile("^\\+[ \\t]*$")
 
@@ -52,6 +53,7 @@ script: |
     }
 
     if r_attribute.match(line) { continue }
+    if r_attribute_list.match(line) { continue }
     if r_list_continue.match(line) { continue }
 
     if r_procedure.match(line) {

--- a/test/TaskStep.bats
+++ b/test/TaskStep.bats
@@ -1,0 +1,33 @@
+load test_helper
+
+@test "Ignore content inside of line and block comments" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_comments.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore content in other sections" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_other_sections.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore attribute lists" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_attribute_lists.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore valid lines with all content variations" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_valid_lines.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Report content other than steps in procedures" {
+  run run_vale "$BATS_TEST_FILENAME" report_non_steps.adoc
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 2 ]
+  [ "${lines[0]}" = "report_non_steps.adoc:6:1:AsciiDocDITA.TaskStep:Content other than a single list cannot be mapped to DITA tasks." ]
+  [ "${lines[1]}" = "report_non_steps.adoc:10:1:AsciiDocDITA.TaskStep:Content other than a single list cannot be mapped to DITA tasks." ]
+}


### PR DESCRIPTION
Fixes issue #15.

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
