### PR TITLE
Do not report lines separated by an empty line if list continuation is present

### DIFF
--- a/fixtures/TaskStep/ignore_valid_lines.adoc
+++ b/fixtures/TaskStep/ignore_valid_lines.adoc
@@ -22,3 +22,19 @@ A false paragraph.
 . A valid step.
 
 .. A valid substep.
+
+. A valid step.
++
+
+A continued step.
+
+. A valid step.
+
++
+A continued step.
+
+. A valid step.
+
++
+
+A continued step.

--- a/styles/AsciiDocDITA/TaskStep.yml
+++ b/styles/AsciiDocDITA/TaskStep.yml
@@ -28,6 +28,7 @@ script: |
   in_procedure      := false
   in_list           := false
   in_step           := false
+  in_continue       := false
   start             := 0
   end               := 0
 
@@ -80,13 +81,18 @@ script: |
     }
 
     if r_empty_line.match(line) {
-      in_step = false
+      if ! in_continue {
+        in_step = false
+      }
       continue
     }
 
     if r_list_continue.match(line) {
+      in_continue = true
       in_step = true
       continue
+    } else {
+      in_continue = false
     }
 
     if r_step.match(line) {


### PR DESCRIPTION
Fixes issue #40.

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
