### PR TITLE
Add a rule to report unsupported block titles

### DIFF
--- a/fixtures/BlockTitle/ignore_block_titles.adoc
+++ b/fixtures/BlockTitle/ignore_block_titles.adoc
@@ -1,0 +1,27 @@
+// Block titles assigned to supported blocks:
+.A supported block title
+image::example.png[]
+
+.A supported block title
+[#example-image]
+image::example.png[Example image,200,200]
+
+.A supported block title
+|===
+|A table cell
+|===
+
+.A supported block title
+[cols="1"]
+|===
+|A table cell
+|===
+
+.A supported block title
+[example]
+An example.
+
+.A supported block title
+====
+An example.
+====

--- a/fixtures/BlockTitle/ignore_comments.adoc
+++ b/fixtures/BlockTitle/ignore_comments.adoc
@@ -1,0 +1,11 @@
+// Block titles assigned to unsupported blocks:
+//.An unsupported block title
+//A paragraph.
+
+////
+.An unsupported block title
+[source,ruby]
+----
+A code block.
+----
+////

--- a/fixtures/BlockTitle/ignore_procedue_titles.adoc
+++ b/fixtures/BlockTitle/ignore_procedue_titles.adoc
@@ -1,0 +1,54 @@
+// Identify the document as a procedure module:
+:_mod-docs-content-type: PROCEDURE
+
+= Topic title
+
+A paragraph.
+
+.Prerequisite
+
+A paragraph.
+
+.Prerequisites
+
+A paragraph.
+
+.Procedure
+
+A paragraph.
+
+.Verification
+
+A paragraph.
+
+.Result
+
+A paragraph.
+
+.Results
+
+A paragraph.
+
+.Troubleshooting
+
+A paragraph.
+
+.Troubleshooting step
+
+A paragraph.
+
+.Troubleshooting steps
+
+A paragraph.
+
+.Next step
+
+A paragraph.
+
+.Next steps
+
+A paragraph.
+
+.Additional resources
+
+A paragraph.

--- a/fixtures/BlockTitle/ignore_steps.adoc
+++ b/fixtures/BlockTitle/ignore_steps.adoc
@@ -1,0 +1,5 @@
+// Steps that look similar to block titles:
+. First step.
+.. First substep.
+
+A paragraph.

--- a/fixtures/BlockTitle/report_block_titles.adoc
+++ b/fixtures/BlockTitle/report_block_titles.adoc
@@ -1,0 +1,12 @@
+// Block titles assigned to unsupported blocks:
+.An unsupported block title
+A paragraph.
+
+.An unsupported block title
+. A list.
+
+.An unsupported block title
+[source,ruby]
+----
+A code block.
+----

--- a/fixtures/BlockTitle/vale.ini
+++ b/fixtures/BlockTitle/vale.ini
@@ -1,0 +1,5 @@
+StylesPath = ../../styles/
+MinAlertLevel = warning
+
+[*.adoc]
+AsciiDocDITA.BlockTitle = YES

--- a/styles/AsciiDocDITA/BlockTitle.yml
+++ b/styles/AsciiDocDITA/BlockTitle.yml
@@ -1,0 +1,77 @@
+# Report unsupported block titles.
+---
+extends: script
+message: "Block titles can only be assigned to examples, figures, and tables in DITA."
+level: warning
+scope: raw
+script: |
+  text              := import("text")
+  matches           := []
+
+  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_comment_block   := text.re_compile("^/{4,}\\s*$")
+  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t](?i:procedure)")
+  r_block_title     := text.re_compile("^\\.{1,2}[^ \\t.].*$")
+  r_supported_title := text.re_compile("^\\.{1,2}(?:Prerequisites?|Procedure|Verification|Results?|Troubleshooting|Troubleshooting steps?|Next steps?|Additional resources)[ \\t]*$")
+  r_example_block   := text.re_compile("^\\[example\\][ \\t]*$")
+  r_example_delim   := text.re_compile("^={4,}[ \\t]*$")
+  r_image           := text.re_compile("^image::(?:\\S|\\S.*\\S)\\[.*\\][ \\t]*$")
+  r_table           := text.re_compile("^\\|={3,}[ \\t]*$")
+  r_attribute       := text.re_compile("^:!?\\S[^:]*:")
+  r_attribute_list  := text.re_compile("^\\[(?:|[\\w.#%{,\"'].*)\\][ \\t]*$")
+  r_conditional     := text.re_compile("^(?:ifn?def|ifeval|endif)::\\S*\\[.*\\][ \\t]*$")
+  r_empty_line      := text.re_compile("^[ \\t]*$")
+
+  document          := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  in_comment_block  := false
+  is_procedure      := false
+  expect_block      := false
+  start             := 0
+  end               := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_content_type.match(line) {
+      is_procedure = true
+      continue
+    }
+
+    if r_attribute_list.match(line) && ! r_example_block.match(line) { continue }
+    if r_attribute.match(line) { continue }
+    if r_conditional.match(line) { continue }
+    if r_empty_line.match(line) { continue }
+
+    if r_block_title.match(line) {
+      if is_procedure && r_supported_title.match(line) { continue }
+
+      expect_block = {begin: start, end: start + end -1}
+      continue
+    }
+
+    if r_table.match(line) || r_image.match(line) ||
+       r_example_block.match(line) || r_example_delim.match(line) {
+      expect_block = false
+      continue
+    }
+
+    if expect_block {
+      matches = append(matches, expect_block)
+    }
+
+    expect_block = false
+  }

--- a/test/BlockTitle.bats
+++ b/test/BlockTitle.bats
@@ -1,0 +1,34 @@
+load test_helper
+
+@test "Ignore block titles inside of line and block comments" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_comments.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore steps that have similar syntax to block titles" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_steps.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore supported block titles in procedure modules" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_procedue_titles.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore supported block titles" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_block_titles.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Report unsupported block titles" {
+  run run_vale "$BATS_TEST_FILENAME" report_block_titles.adoc
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 3 ]
+  [ "${lines[0]}" = "report_block_titles.adoc:2:1:AsciiDocDITA.BlockTitle:Block titles can only be assigned to examples, figures, and tables in DITA." ]
+  [ "${lines[1]}" = "report_block_titles.adoc:5:1:AsciiDocDITA.BlockTitle:Block titles can only be assigned to examples, figures, and tables in DITA." ]
+  [ "${lines[2]}" = "report_block_titles.adoc:8:1:AsciiDocDITA.BlockTitle:Block titles can only be assigned to examples, figures, and tables in DITA." ]
+}


### PR DESCRIPTION
Fixes issue #6.

### Implementation checklist

- [X] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [X] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
