### PR TITLE
Add a rule to report invalid example blocks

### DIFF
--- a/fixtures/ExampleBlock/ignore_admonitions.adoc
+++ b/fixtures/ExampleBlock/ignore_admonitions.adoc
@@ -1,0 +1,8 @@
+// An admonition that uses the same block syntax:
+
+== Section title
+
+[NOTE]
+====
+A valid admonition.
+====

--- a/fixtures/ExampleBlock/ignore_comments.adoc
+++ b/fixtures/ExampleBlock/ignore_comments.adoc
@@ -1,0 +1,11 @@
+// Unsupported examples in comments:
+== Section title
+
+//[example]
+//An unsupported example.
+
+////
+====
+An unsupported example.
+====
+////

--- a/fixtures/ExampleBlock/ignore_valid_examples.adoc
+++ b/fixtures/ExampleBlock/ignore_valid_examples.adoc
@@ -1,0 +1,21 @@
+// Supported examples in the main body of the document:
+= Topic title
+
+A paragraph.
+
+.An example title
+====
+A valid example.
+====
+
+. A list item.
+. A list item.
++
+A paragraph.
+
+[example]
+A valid example.
+
+== Section title
+
+A paragraph.

--- a/fixtures/ExampleBlock/report_example_in_block.adoc
+++ b/fixtures/ExampleBlock/report_example_in_block.adoc
@@ -1,0 +1,17 @@
+// An unsupported example in a sidebar block:
+****
+A paragraph.
+
+====
+An unsupported example.
+====
+****
+
+// An unsupported example in a delimited block:
+--
+A paragraph.
+
+====
+An unsupported example.
+====
+--

--- a/fixtures/ExampleBlock/report_example_in_list.adoc
+++ b/fixtures/ExampleBlock/report_example_in_list.adoc
@@ -1,0 +1,21 @@
+// Unsupported examples in list items:
+* A list item.
++
+.An example title
+====
+An unsupported example.
+====
+
+- A list item.
++
+
+[example]
+An unsupported example.
+
+. A list item.
++
+A paragraph.
++
+====
+An unsupported example.
+====

--- a/fixtures/ExampleBlock/report_example_in_section.adoc
+++ b/fixtures/ExampleBlock/report_example_in_section.adoc
@@ -1,0 +1,9 @@
+// Unsupported examples in sections:
+== Section title
+
+[example]
+An unsupported example.
+
+====
+An unsupported example.
+====

--- a/fixtures/ExampleBlock/vale.ini
+++ b/fixtures/ExampleBlock/vale.ini
@@ -1,0 +1,5 @@
+StylesPath = ../../styles/
+MinAlertLevel = warning
+
+[*.adoc]
+AsciiDocDITA.ExampleBlock = YES

--- a/styles/AsciiDocDITA/ExampleBlock.yml
+++ b/styles/AsciiDocDITA/ExampleBlock.yml
@@ -1,0 +1,133 @@
+# Report unsupported example blocks.
+---
+extends: script
+message: "Examples can not be inside of other blocks in DITA."
+level: error
+scope: raw
+script: |
+  text               := import("text")
+  matches            := []
+
+  r_comment_line     := text.re_compile("^(//|//[^/].*)$")
+  r_comment_block    := text.re_compile("^/{4,}\\s*$")
+  r_admonition_block := text.re_compile("^\\[(?:NOTE|TIP|IMPORTANT|WARNING|CAUTION)\\][ \\t]*$")
+  r_code_block       := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
+  r_other_block      := text.re_compile("^(?:\\*{4,}|-{2})[ \\t]*$")
+  r_section          := text.re_compile("^={2,}[ \\t]\\S.*$")
+  r_example_block    := text.re_compile("^\\[example\\][ \\t]*$")
+  r_example_delim    := text.re_compile("^={4,}[ \\t]*$")
+  r_list_item        := text.re_compile("^[ \\t]*[\\*-.]+[ \\t]+\\S.*$")
+  r_list_continue    := text.re_compile("^\\+[ \\t]*$")
+  r_attribute        := text.re_compile("^:!?\\S[^:]*:")
+  r_conditional      := text.re_compile("^(?:ifn?def|ifeval|endif)::\\S*\\[.*\\][ \\t]*$")
+  r_empty_line       := text.re_compile("^[ \\t]*$")
+
+  document           := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  in_comment_block   := false
+  in_example_block   := false
+  in_code_block      := false
+  in_other_block     := false
+  in_section         := false
+  in_list            := false
+  in_continue        := false
+  expect_admonition  := false
+  start              := 0
+  end                := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_code_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_code_block {
+        in_code_block = delimiter
+      } else if in_code_block == delimiter {
+        in_code_block = false
+      }
+      in_continue = false
+      continue
+    }
+
+    if r_attribute.match(line) { continue }
+    if r_conditional.match(line) { continue }
+
+    if r_example_delim.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_example_block {
+        in_example_block = delimiter
+
+        if expect_admonition { continue }
+
+        if in_section || in_other_block || in_list {
+          matches = append(matches, {begin: start, end: start + end - 1})
+        }
+      } else if in_example_block == delimiter {
+        in_example_block = false
+      }
+      in_continue = false
+      continue
+    }
+
+    if r_empty_line.match(line) {
+      if ! in_continue {
+        in_list = false
+      }
+      continue
+    }
+
+    if r_list_continue.match(line) {
+      in_continue = true
+      in_list = true
+      continue
+    } else {
+      in_continue = false
+    }
+
+    if r_list_item.match(line) {
+      in_list = true
+      continue
+    }
+
+    if r_admonition_block.match(line) {
+      expect_admonition = true
+      continue
+    }
+
+    if r_section.match(line) {
+      in_section = true
+      continue
+    }
+
+    if r_example_block.match(line) {
+      if in_section || in_other_block || in_list {
+        matches = append(matches, {begin: start, end: start + end - 1})
+      }
+      continue
+    }
+
+    if r_other_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_other_block {
+        in_other_block = delimiter
+      } else if in_other_block == delimiter {
+        in_other_block = false
+      }
+      continue
+    }
+
+    expect_admonition = false
+  }

--- a/test/ExampleBlock.bats
+++ b/test/ExampleBlock.bats
@@ -1,0 +1,44 @@
+load test_helper
+
+@test "Ignore example blocks inside of line and block comments" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_comments.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore admonitions that use the same delimiter as example blocks" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_admonitions.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore supported example blocks" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_valid_examples.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Report example blocks in other blocks" {
+  run run_vale "$BATS_TEST_FILENAME" report_example_in_block.adoc
+  [ "$status" -eq 1 ]
+  [ "${#lines[@]}" -eq 2 ]
+  [ "${lines[0]}" = "report_example_in_block.adoc:5:1:AsciiDocDITA.ExampleBlock:Examples can not be inside of other blocks in DITA." ]
+  [ "${lines[1]}" = "report_example_in_block.adoc:14:1:AsciiDocDITA.ExampleBlock:Examples can not be inside of other blocks in DITA." ]
+}
+
+@test "Report example blocks in list items" {
+  run run_vale "$BATS_TEST_FILENAME" report_example_in_list.adoc
+  [ "$status" -eq 1 ]
+  [ "${#lines[@]}" -eq 3 ]
+  [ "${lines[0]}" = "report_example_in_list.adoc:5:1:AsciiDocDITA.ExampleBlock:Examples can not be inside of other blocks in DITA." ]
+  [ "${lines[1]}" = "report_example_in_list.adoc:12:1:AsciiDocDITA.ExampleBlock:Examples can not be inside of other blocks in DITA." ]
+  [ "${lines[2]}" = "report_example_in_list.adoc:19:1:AsciiDocDITA.ExampleBlock:Examples can not be inside of other blocks in DITA." ]
+}
+
+@test "Report example blocks in sections" {
+  run run_vale "$BATS_TEST_FILENAME" report_example_in_section.adoc
+  [ "$status" -eq 1 ]
+  [ "${#lines[@]}" -eq 2 ]
+  [ "${lines[0]}" = "report_example_in_section.adoc:4:1:AsciiDocDITA.ExampleBlock:Examples can not be inside of other blocks in DITA." ]
+  [ "${lines[1]}" = "report_example_in_section.adoc:7:1:AsciiDocDITA.ExampleBlock:Examples can not be inside of other blocks in DITA." ]
+}


### PR DESCRIPTION
Fixes issue #45.

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
