### PR TITLE
Issue #46: Do not report Additional resources as an invalid block title

### DIFF
--- a/fixtures/BlockTitle/ignore_additional_resources.adoc
+++ b/fixtures/BlockTitle/ignore_additional_resources.adoc
@@ -1,0 +1,10 @@
+// Identify the document as a concept module:
+:_mod-docs-content-type: CONCEPT
+
+= Topic title
+
+A paragraph
+
+.Additional resources
+
+A paragraph.

--- a/styles/AsciiDocDITA/BlockTitle.yml
+++ b/styles/AsciiDocDITA/BlockTitle.yml
@@ -12,7 +12,8 @@ script: |
   r_comment_block   := text.re_compile("^/{4,}\\s*$")
   r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t](?i:procedure)")
   r_block_title     := text.re_compile("^\\.{1,2}[^ \\t.].*$")
-  r_supported_title := text.re_compile("^\\.{1,2}(?:Prerequisites?|Procedure|Verification|Results?|Troubleshooting|Troubleshooting steps?|Next steps?|Additional resources)[ \\t]*$")
+  r_supported_title := text.re_compile("^\\.{1,2}(?:Prerequisites?|Procedure|Verification|Results?|Troubleshooting|Troubleshooting steps?|Next steps?)[ \\t]*$")
+  r_add_resources   := text.re_compile("^\\.{1,2}Additional resources[ \\t]*$")
   r_example_block   := text.re_compile("^\\[example\\][ \\t]*$")
   r_example_delim   := text.re_compile("^={4,}[ \\t]*$")
   r_image           := text.re_compile("^image::(?:\\S|\\S.*\\S)\\[.*\\][ \\t]*$")
@@ -58,6 +59,7 @@ script: |
 
     if r_block_title.match(line) {
       if is_procedure && r_supported_title.match(line) { continue }
+      if r_add_resources.match(line) { continue }
 
       expect_block = {begin: start, end: start + end -1}
       continue

--- a/test/BlockTitle.bats
+++ b/test/BlockTitle.bats
@@ -18,6 +18,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore additional resources in all modules" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_additional_resources.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Ignore supported block titles" {
   run run_vale "$BATS_TEST_FILENAME" ignore_block_titles.adoc
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Fixes issue #46.

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [ ] The new code passes all tests (run `make test` in the project directory)
