### PR TITLE
Add a rule to report conditional directives

### DIFF
--- a/fixtures/ConditionalCode/ignore_comments.adoc
+++ b/fixtures/ConditionalCode/ignore_comments.adoc
@@ -1,0 +1,5 @@
+// Conditional directives in line comments:
+
+//ifdef::beginner-content[]
+//A paragraph.
+//endif::[]

--- a/fixtures/ConditionalCode/ignore_escapes.adoc
+++ b/fixtures/ConditionalCode/ignore_escapes.adoc
@@ -1,0 +1,5 @@
+// Escaped conditional directives:
+
+\ifdef::beginner-content[]
+A paragraph.
+\endif::[]

--- a/fixtures/ConditionalCode/report_conditionals.adoc
+++ b/fixtures/ConditionalCode/report_conditionals.adoc
@@ -1,0 +1,17 @@
+// Valid conditional directive variations:
+
+ifdef::beginner-content[]
+A paragraph.
+endif::[]
+
+ifdef::beginner-content[A paragraph.]
+
+ifndef::beginner-content[]
+A paragraph.
+endif::[]
+
+ifndef::beginner-content[A paragraph.]
+
+ifeval::["{version-number}" == "1.0.0"]
+A paragraph.
+endif::[]

--- a/fixtures/ConditionalCode/vale.ini
+++ b/fixtures/ConditionalCode/vale.ini
@@ -1,0 +1,5 @@
+StylesPath = ../../styles/
+MinAlertLevel = suggestion
+
+[*.adoc]
+AsciiDocDITA.ConditionalCode = YES

--- a/styles/AsciiDocDITA/ConditionalCode.yml
+++ b/styles/AsciiDocDITA/ConditionalCode.yml
@@ -1,0 +1,9 @@
+# Report conditional directives.
+---
+extends: existence
+message: "%s"
+level: suggestion
+scope: raw
+nonword: true
+tokens:
+  - '^(?:ifn?def|ifeval)::\S*\[.*\][ \t]*$'

--- a/test/ConditionalCode.bats
+++ b/test/ConditionalCode.bats
@@ -1,0 +1,24 @@
+load test_helper
+
+@test "Ignore conditional directives in line comments" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_comments.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore escaped conditional directives" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_escapes.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Report conditional directive variations" {
+  run run_vale "$BATS_TEST_FILENAME" report_conditionals.adoc
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 5 ]
+  [ "${lines[0]}" = "report_conditionals.adoc:3:1:AsciiDocDITA.ConditionalCode:ifdef::beginner-content[]" ]
+  [ "${lines[1]}" = "report_conditionals.adoc:7:1:AsciiDocDITA.ConditionalCode:ifdef::beginner-content[A paragraph.]" ]
+  [ "${lines[2]}" = "report_conditionals.adoc:9:1:AsciiDocDITA.ConditionalCode:ifndef::beginner-content[]" ]
+  [ "${lines[3]}" = "report_conditionals.adoc:13:1:AsciiDocDITA.ConditionalCode:ifndef::beginner-content[A paragraph.]" ]
+  [ "${lines[4]}" = "report_conditionals.adoc:15:1:AsciiDocDITA.ConditionalCode:ifeval::[\"{version-number}\" == \"1.0.0\"]" ]
+}


### PR DESCRIPTION
Conditional directives need to be resolved at conversion time. This rule gives the user an overview of all conditions that are present in the AsciiDoc file so that they can decide which attributes to supply during conversion.

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
