### PR TITLE
Add a rule to report multiple examples in a procedure module

### DIFF
--- a/fixtures/TaskExample/ignore_admonitions.adoc
+++ b/fixtures/TaskExample/ignore_admonitions.adoc
@@ -1,0 +1,14 @@
+// Admonitions that use the same block syntax:
+:_mod-docs-content-type: PROCEDURE
+
+[NOTE]
+====
+An admonition.
+====
+
+[NOTE]
+An admonition.
+
+====
+A supported example.
+====

--- a/fixtures/TaskExample/ignore_comments.adoc
+++ b/fixtures/TaskExample/ignore_comments.adoc
@@ -1,0 +1,14 @@
+// Multiple examples in comments:
+:_mod-docs-content-type: PROCEDURE
+
+[example]
+A supported example.
+
+//====
+//An unsupported example.
+//====
+
+////
+[example]
+An unsupported example.
+////

--- a/fixtures/TaskExample/ignore_other_modules.adoc
+++ b/fixtures/TaskExample/ignore_other_modules.adoc
@@ -1,0 +1,12 @@
+// Multiple examples in a concept module:
+:_mod-docs-content-type: CONCEPT
+
+[example]
+A supported example.
+
+====
+An unsupported example.
+====
+
+[example]
+An unsupported example.

--- a/fixtures/TaskExample/ignore_single_example.adoc
+++ b/fixtures/TaskExample/ignore_single_example.adoc
@@ -1,0 +1,6 @@
+// A single example in a procedure module:
+:_mod-docs-content-type: PROCEDURE
+
+====
+A supported example.
+====

--- a/fixtures/TaskExample/report_multiple_examples.adoc
+++ b/fixtures/TaskExample/report_multiple_examples.adoc
@@ -1,0 +1,12 @@
+// Multiple examples in a procedure module:
+:_mod-docs-content-type: PROCEDURE
+
+[example]
+A supported example.
+
+====
+An unsupported example.
+====
+
+[example]
+An unsupported example.

--- a/fixtures/TaskExample/vale.ini
+++ b/fixtures/TaskExample/vale.ini
@@ -1,0 +1,5 @@
+StylesPath = ../../styles/
+MinAlertLevel = warning
+
+[*.adoc]
+AsciiDocDITA.TaskExample = YES

--- a/styles/AsciiDocDITA/TaskExample.yml
+++ b/styles/AsciiDocDITA/TaskExample.yml
@@ -1,0 +1,91 @@
+# Report extra examples inside of procedure modules.
+---
+extends: script
+message: "Examples are allowed only once in DITA tasks."
+level: error
+scope: raw
+script: |
+  text               := import("text")
+  matches            := []
+
+  r_admonition_block := text.re_compile("^\\[(?:NOTE|TIP|IMPORTANT|WARNING|CAUTION)\\][ \\t]*$")
+  r_comment_block    := text.re_compile("^/{4,}\\s*$")
+  r_comment_line     := text.re_compile("^(//|//[^/].*)$")
+  r_conditional      := text.re_compile("^(?:ifn?def|ifeval|endif)::\\S*\\[.*\\][ \\t]*$")
+  r_content_type     := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t](?i:procedure)")
+  r_empty_line       := text.re_compile("^[ \\t]*$")
+  r_example_block    := text.re_compile("^\\[example\\][ \\t]*$")
+  r_example_delim    := text.re_compile("^={4,}[ \\t]*$")
+
+  document           := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  expect_admonition  := false
+  in_comment_block   := false
+  in_example_block   := false
+  is_procedure       := false
+  count              := 0
+  start              := 0
+  end                := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_conditional.match(line) { continue }
+    if r_empty_line.match(line) { continue }
+
+    if r_content_type.match(line) {
+      is_procedure = true
+      continue
+    }
+
+    if r_admonition_block.match(line) {
+      expect_admonition = true
+      continue
+    }
+
+    if r_example_delim.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_example_block {
+        count++
+        in_example_block = delimiter
+
+        if expect_admonition { continue }
+
+        if count > 1 {
+          matches = append(matches, {begin: start, end: start + end - 1})
+        }
+      } else if in_example_block == delimiter {
+        in_example_block = false
+      }
+      continue
+    }
+
+    if r_example_block.match(line) {
+      count++
+
+      if count > 1 {
+        matches = append(matches, {begin: start, end: start + end - 1})
+      }
+
+      continue
+    }
+
+    expect_admonition = false
+  }
+
+  if ! is_procedure {
+    matches = []
+  }

--- a/styles/AsciiDocDITA/TaskExample.yml
+++ b/styles/AsciiDocDITA/TaskExample.yml
@@ -59,10 +59,14 @@ script: |
     if r_example_delim.match(line) {
       delimiter := text.trim_space(line)
       if ! in_example_block {
-        count++
         in_example_block = delimiter
 
-        if expect_admonition { continue }
+        if expect_admonition {
+          expect_admonition = false
+          continue
+        }
+
+        count++
 
         if count > 1 {
           matches = append(matches, {begin: start, end: start + end - 1})

--- a/test/TaskExample.bats
+++ b/test/TaskExample.bats
@@ -1,0 +1,33 @@
+load test_helper
+
+@test "Ignore example blocks inside of line and block comments" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_comments.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore admonitions that use the same delimiter as example blocks" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_admonitions.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore supported example blocks" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_single_example.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore example blocks in other content types" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_other_modules.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Report extra example blocks" {
+  run run_vale "$BATS_TEST_FILENAME" report_multiple_examples.adoc
+  [ "$status" -eq 1 ]
+  [ "${#lines[@]}" -eq 2 ]
+  [ "${lines[0]}" = "report_multiple_examples.adoc:7:1:AsciiDocDITA.TaskExample:Examples are allowed only once in DITA tasks." ]
+  [ "${lines[1]}" = "report_multiple_examples.adoc:11:1:AsciiDocDITA.TaskExample:Examples are allowed only once in DITA tasks." ]
+}


### PR DESCRIPTION
Fixes issue #53.

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)