### PR TITLE
Add a rule to report tag directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The following rules have their severity set to `suggestion`. These are convenien
 | AttributeReference | Lists all [attribute references](https://docs.asciidoctor.org/asciidoc/latest/attributes/reference-attributes/) in the file. Use this information to decide which attribute definitions to supply during conversion. |
 | ConditionalCode | Lists all `ifdef`, `ifndef`, and `ifeval` [conditional statements](https://docs.asciidoctor.org/asciidoc/latest/directives/conditionals/) in the file. Use this information to decide which attribute definitions to supply during conversion. |
 | IncludeDirective | Lists all [include directives](https://docs.asciidoctor.org/asciidoc/latest/directives/include/) in the file. Use this information to decide if include directives should be processed during conversion. |
+| TagDirective | Lists all [tag directives](https://docs.asciidoctor.org/asciidoc/latest/directives/include-tagged-regions/) in the file. Use this information to decide how to approach conditional content after conversion. |
 | ShortDescription | Suggest assigning `[role="_abstract"]` to a paragraph you want to convert to the `<shortdesc>` element in DITA. |
 
 ## Copyright

--- a/fixtures/TagDirective/report_comments.adoc
+++ b/fixtures/TagDirective/report_comments.adoc
@@ -1,0 +1,5 @@
+// Tag directives in line comments:
+
+// tag::verbose[]
+A paragraph.
+// end::verbose[]

--- a/fixtures/TagDirective/report_tags.adoc
+++ b/fixtures/TagDirective/report_tags.adoc
@@ -1,0 +1,13 @@
+// Valid tag directive variations:
+
+tag::verbose[]
+A paragraph.
+end::verbose[]
+
+[source,ruby]
+----
+# tag::verbose[]
+# A comment:
+# end::verbose[]
+puts "A string"
+----

--- a/fixtures/TagDirective/vale.ini
+++ b/fixtures/TagDirective/vale.ini
@@ -1,0 +1,5 @@
+StylesPath = ../../styles/
+MinAlertLevel = suggestion
+
+[*.adoc]
+AsciiDocDITA.TagDirective = YES

--- a/styles/AsciiDocDITA/TagDirective.yml
+++ b/styles/AsciiDocDITA/TagDirective.yml
@@ -1,0 +1,9 @@
+# Report tag directives.
+---
+extends: existence
+message: "%s"
+level: suggestion
+scope: raw
+nonword: true
+tokens:
+  - '\btag::\S+?\[\][ \t]*$'

--- a/test/TagDirective.bats
+++ b/test/TagDirective.bats
@@ -1,0 +1,16 @@
+load test_helper
+
+@test "Report tag directive variations" {
+  run run_vale "$BATS_TEST_FILENAME" report_tags.adoc
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 2 ]
+  [ "${lines[0]}" = "report_tags.adoc:3:1:AsciiDocDITA.TagDirective:tag::verbose[]" ]
+  [ "${lines[1]}" = "report_tags.adoc:9:3:AsciiDocDITA.TagDirective:tag::verbose[]" ]
+}
+
+@test "Report tag directives in line comments" {
+  run run_vale "$BATS_TEST_FILENAME" report_comments.adoc
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 1 ]
+  [ "${lines[0]}" = "report_comments.adoc:3:4:AsciiDocDITA.TagDirective:tag::verbose[]" ]
+}


### PR DESCRIPTION
Fixes issue #61.

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [x] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
