### PR TITLE
Issue #66: Do not report examples in code blocks

### DIFF
--- a/fixtures/ExampleBlock/ignore_admonitions.adoc
+++ b/fixtures/ExampleBlock/ignore_admonitions.adoc
@@ -1,5 +1,4 @@
 // An admonition that uses the same block syntax:
-
 == Section title
 
 [NOTE]

--- a/fixtures/ExampleBlock/ignore_code_blocks.adoc
+++ b/fixtures/ExampleBlock/ignore_code_blocks.adoc
@@ -1,0 +1,35 @@
+// Multiple examples in code blocks:
+== Section title
+
+[literal,subs="+quotes"]
+....
+[example]
+An unsupported example.
+....
+
+[literal,subs="+quotes"]
+....
+====
+An unsupported example.
+====
+....
+
+[source,asciidoc]
+----
+[example]
+An unsupported example.
+----
+
+[source,asciidoc]
+----
+====
+An unsupported example.
+====
+----
+
+----
+===============================================
+Playbook: test_playbook
+Description: This playbook serves as a test.
+-----------------------------------------------
+----

--- a/fixtures/TaskExample/ignore_code_blocks.adoc
+++ b/fixtures/TaskExample/ignore_code_blocks.adoc
@@ -1,0 +1,38 @@
+// Multiple examples in code blocks:
+:_mod-docs-content-type: PROCEDURE
+
+[example]
+A supported example.
+
+[literal,subs="+quotes"]
+....
+[example]
+An unsupported example.
+....
+
+[literal,subs="+quotes"]
+....
+====
+An unsupported example.
+====
+....
+
+[source,asciidoc]
+----
+[example]
+An unsupported example.
+----
+
+[source,asciidoc]
+----
+====
+An unsupported example.
+====
+----
+
+----
+===============================================
+Playbook: test_playbook
+Description: This playbook serves as a test.
+-----------------------------------------------
+----

--- a/styles/AsciiDocDITA/ExampleBlock.yml
+++ b/styles/AsciiDocDITA/ExampleBlock.yml
@@ -61,6 +61,7 @@ script: |
       in_continue = false
       continue
     }
+    if in_code_block { continue }
 
     if r_attribute.match(line) { continue }
     if r_conditional.match(line) { continue }

--- a/styles/AsciiDocDITA/TaskExample.yml
+++ b/styles/AsciiDocDITA/TaskExample.yml
@@ -11,6 +11,7 @@ script: |
   r_admonition_block := text.re_compile("^\\[(?:NOTE|TIP|IMPORTANT|WARNING|CAUTION)\\][ \\t]*$")
   r_comment_block    := text.re_compile("^/{4,}\\s*$")
   r_comment_line     := text.re_compile("^(//|//[^/].*)$")
+  r_code_block       := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
   r_conditional      := text.re_compile("^(?:ifn?def|ifeval|endif)::\\S*\\[.*\\][ \\t]*$")
   r_content_type     := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t](?i:procedure)")
   r_empty_line       := text.re_compile("^[ \\t]*$")
@@ -21,6 +22,7 @@ script: |
 
   expect_admonition  := false
   in_comment_block   := false
+  in_code_block      := false
   in_example_block   := false
   is_procedure       := false
   count              := 0
@@ -42,6 +44,17 @@ script: |
     }
     if in_comment_block { continue }
     if r_comment_line.match(line) { continue }
+
+    if r_code_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_code_block {
+        in_code_block = delimiter
+      } else if in_code_block == delimiter {
+        in_code_block = false
+      }
+      continue
+    }
+    if in_code_block { continue }
 
     if r_conditional.match(line) { continue }
     if r_empty_line.match(line) { continue }

--- a/test/ExampleBlock.bats
+++ b/test/ExampleBlock.bats
@@ -6,6 +6,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore example blocks inside of code blocks" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_code_blocks.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Ignore admonitions that use the same delimiter as example blocks" {
   run run_vale "$BATS_TEST_FILENAME" ignore_admonitions.adoc
   [ "$status" -eq 0 ]

--- a/test/TaskExample.bats
+++ b/test/TaskExample.bats
@@ -6,6 +6,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore example blocks inside of code blocks" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_code_blocks.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Ignore admonitions that use the same delimiter as example blocks" {
   run run_vale "$BATS_TEST_FILENAME" ignore_admonitions.adoc
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Fixes issue #66.

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [x] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
