### PR TITLE
Issue #65: Do not report admonitions as invalid examples

### DIFF
--- a/fixtures/ExampleBlock/ignore_admonitions.adoc
+++ b/fixtures/ExampleBlock/ignore_admonitions.adoc
@@ -3,5 +3,65 @@
 
 [NOTE]
 ====
-A valid admonition.
+An admonition.
+====
+
+[TIP]
+====
+An admonition.
+====
+
+[IMPORTANT]
+====
+An admonition.
+====
+
+[WARNING]
+====
+An admonition.
+====
+
+[CAUTION]
+====
+An admonition.
+====
+
+.An admonition title
+[NOTE]
+====
+An admonition.
+====
+
+[NOTE]
+.An admonition title
+====
+An admonition.
+====
+
+[NOTE]
+
+
+====
+An admonition.
+====
+
+. A step.
++
+[NOTE]
++
+====
+An admonition.
+====
+
+. A step.
+
++
+
+[NOTE]
+
+
++
+
+====
+An admonition.
 ====

--- a/fixtures/TaskExample/ignore_admonitions.adoc
+++ b/fixtures/TaskExample/ignore_admonitions.adoc
@@ -1,14 +1,70 @@
 // Admonitions that use the same block syntax:
 :_mod-docs-content-type: PROCEDURE
 
-[NOTE]
-====
-An admonition.
-====
-
-[NOTE]
-An admonition.
-
-====
+[example]
 A supported example.
+
+[NOTE]
+====
+An admonition.
+====
+
+[TIP]
+====
+An admonition.
+====
+
+[IMPORTANT]
+====
+An admonition.
+====
+
+[WARNING]
+====
+An admonition.
+====
+
+[CAUTION]
+====
+An admonition.
+====
+
+.An admonition title
+[NOTE]
+====
+An admonition.
+====
+
+[NOTE]
+.An admonition title
+====
+An admonition.
+====
+
+[NOTE]
+
+
+====
+An admonition.
+====
+
+. A step.
++
+[NOTE]
++
+====
+An admonition.
+====
+
+. A step.
+
++
+
+[NOTE]
+
+
++
+
+====
+An admonition.
 ====

--- a/styles/AsciiDocDITA/ExampleBlock.yml
+++ b/styles/AsciiDocDITA/ExampleBlock.yml
@@ -8,19 +8,20 @@ script: |
   text               := import("text")
   matches            := []
 
-  r_comment_line     := text.re_compile("^(//|//[^/].*)$")
-  r_comment_block    := text.re_compile("^/{4,}\\s*$")
   r_admonition_block := text.re_compile("^\\[(?:NOTE|TIP|IMPORTANT|WARNING|CAUTION)\\][ \\t]*$")
-  r_code_block       := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
-  r_other_block      := text.re_compile("^(?:\\*{4,}|-{2})[ \\t]*$")
-  r_section          := text.re_compile("^={2,}[ \\t]\\S.*$")
-  r_example_block    := text.re_compile("^\\[example\\][ \\t]*$")
-  r_example_delim    := text.re_compile("^={4,}[ \\t]*$")
-  r_list_item        := text.re_compile("^[ \\t]*[\\*-.]+[ \\t]+\\S.*$")
-  r_list_continue    := text.re_compile("^\\+[ \\t]*$")
   r_attribute        := text.re_compile("^:!?\\S[^:]*:")
+  r_block_title      := text.re_compile("^\\.{1,2}[^ \\t.].*$")
+  r_code_block       := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
+  r_comment_block    := text.re_compile("^/{4,}\\s*$")
+  r_comment_line     := text.re_compile("^(//|//[^/].*)$")
   r_conditional      := text.re_compile("^(?:ifn?def|ifeval|endif)::\\S*\\[.*\\][ \\t]*$")
   r_empty_line       := text.re_compile("^[ \\t]*$")
+  r_example_block    := text.re_compile("^\\[example\\][ \\t]*$")
+  r_example_delim    := text.re_compile("^={4,}[ \\t]*$")
+  r_list_continue    := text.re_compile("^\\+[ \\t]*$")
+  r_list_item        := text.re_compile("^[ \\t]*[\\*-.]+[ \\t]+\\S.*$")
+  r_other_block      := text.re_compile("^(?:\\*{4,}|-{2})[ \\t]*$")
+  r_section          := text.re_compile("^={2,}[ \\t]\\S.*$")
 
   document           := text.split(text.trim_suffix(scope, "\n"), "\n")
 
@@ -96,6 +97,13 @@ script: |
       continue
     } else {
       in_continue = false
+    }
+
+    if r_block_title.match(line) && expect_admonition {
+      if in_continue {
+        in_continue = false
+      }
+      continue
     }
 
     if r_list_item.match(line) {

--- a/styles/AsciiDocDITA/TaskExample.yml
+++ b/styles/AsciiDocDITA/TaskExample.yml
@@ -9,6 +9,7 @@ script: |
   matches            := []
 
   r_admonition_block := text.re_compile("^\\[(?:NOTE|TIP|IMPORTANT|WARNING|CAUTION)\\][ \\t]*$")
+  r_block_title      := text.re_compile("^\\.{1,2}[^ \\t.].*$")
   r_comment_block    := text.re_compile("^/{4,}\\s*$")
   r_comment_line     := text.re_compile("^(//|//[^/].*)$")
   r_code_block       := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
@@ -17,6 +18,7 @@ script: |
   r_empty_line       := text.re_compile("^[ \\t]*$")
   r_example_block    := text.re_compile("^\\[example\\][ \\t]*$")
   r_example_delim    := text.re_compile("^={4,}[ \\t]*$")
+  r_list_continue    := text.re_compile("^\\+[ \\t]*$")
 
   document           := text.split(text.trim_suffix(scope, "\n"), "\n")
 
@@ -67,6 +69,12 @@ script: |
     if r_admonition_block.match(line) {
       expect_admonition = true
       continue
+    }
+
+    if expect_admonition {
+      if r_block_title.match(line) || r_list_continue.match(line) {
+        continue
+      }
     }
 
     if r_example_delim.match(line) {


### PR DESCRIPTION
Fixes issue #65.

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [x] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
