### PR TITLE
Issue #74: Do not report cell formatting as a BlockTitle warning

### DIFF
--- a/fixtures/BlockTitle/ignore_table_cells.adoc
+++ b/fixtures/BlockTitle/ignore_table_cells.adoc
@@ -1,0 +1,8 @@
+// Table cells with vertical alignment operators:
+[cols="2,1"]
+|===
+|First column |Second column
+
+.>|First cell
+|Second cell with a long paragraph so that the previous cell is visibly aligned to the bottom.
+|===

--- a/styles/AsciiDocDITA/BlockTitle.yml
+++ b/styles/AsciiDocDITA/BlockTitle.yml
@@ -8,20 +8,21 @@ script: |
   text              := import("text")
   matches           := []
 
-  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
-  r_comment_block   := text.re_compile("^/{4,}\\s*$")
-  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t](?i:procedure)")
-  r_block_title     := text.re_compile("^\\.{1,2}[^ \\t.].*$")
-  r_supported_title := text.re_compile("^\\.{1,2}(?:Prerequisites?|Procedure|Verification|Results?|Troubleshooting|Troubleshooting steps?|Next steps?)[ \\t]*$")
   r_add_resources   := text.re_compile("^\\.{1,2}Additional resources[ \\t]*$")
+  r_attribute_list  := text.re_compile("^\\[(?:|[\\w.#%{,\"'].*)\\][ \\t]*$")
+  r_attribute       := text.re_compile("^:!?\\S[^:]*:")
+  r_block_title     := text.re_compile("^\\.{1,2}[^ \\t.].*$")
+  r_comment_block   := text.re_compile("^/{4,}\\s*$")
+  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_conditional     := text.re_compile("^(?:ifn?def|ifeval|endif)::\\S*\\[.*\\][ \\t]*$")
+  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t](?i:procedure)")
+  r_empty_line      := text.re_compile("^[ \\t]*$")
   r_example_block   := text.re_compile("^\\[example\\][ \\t]*$")
   r_example_delim   := text.re_compile("^={4,}[ \\t]*$")
   r_image           := text.re_compile("^image::(?:\\S|\\S.*\\S)\\[.*\\][ \\t]*$")
+  r_supported_title := text.re_compile("^\\.{1,2}(?:Prerequisites?|Procedure|Verification|Results?|Troubleshooting|Troubleshooting steps?|Next steps?)[ \\t]*$")
+  r_table_cell      := text.re_compile("^\\.[^ \\t]+\\|")
   r_table           := text.re_compile("^\\|={3,}[ \\t]*$")
-  r_attribute       := text.re_compile("^:!?\\S[^:]*:")
-  r_attribute_list  := text.re_compile("^\\[(?:|[\\w.#%{,\"'].*)\\][ \\t]*$")
-  r_conditional     := text.re_compile("^(?:ifn?def|ifeval|endif)::\\S*\\[.*\\][ \\t]*$")
-  r_empty_line      := text.re_compile("^[ \\t]*$")
 
   document          := text.split(text.trim_suffix(scope, "\n"), "\n")
 
@@ -60,6 +61,7 @@ script: |
     if r_block_title.match(line) {
       if is_procedure && r_supported_title.match(line) { continue }
       if r_add_resources.match(line) { continue }
+      if r_table_cell.match(line) { continue }
 
       expect_block = {begin: start, end: start + end -1}
       continue

--- a/styles/AsciiDocDITA/BlockTitle.yml
+++ b/styles/AsciiDocDITA/BlockTitle.yml
@@ -21,7 +21,7 @@ script: |
   r_example_delim   := text.re_compile("^={4,}[ \\t]*$")
   r_image           := text.re_compile("^image::(?:\\S|\\S.*\\S)\\[.*\\][ \\t]*$")
   r_supported_title := text.re_compile("^\\.{1,2}(?:Prerequisites?|Procedure|Verification|Results?|Troubleshooting|Troubleshooting steps?|Next steps?)[ \\t]*$")
-  r_table_cell      := text.re_compile("^\\.[^ \\t]+\\|")
+  r_table_cell      := text.re_compile("^\\.[^ \\t|]+\\|")
   r_table           := text.re_compile("^\\|={3,}[ \\t]*$")
 
   document          := text.split(text.trim_suffix(scope, "\n"), "\n")

--- a/styles/AsciiDocDITA/TaskDuplicate.yml
+++ b/styles/AsciiDocDITA/TaskDuplicate.yml
@@ -14,7 +14,7 @@ script: |
 
   titles            := {}
   titles.prereq      = text.re_compile("^\\.{1,2}Prerequisites?[ \\t]*$")
-  titles.steps       = text.re_compile("^\\.{1,2}Procedure?[ \\t]*$")
+  titles.steps       = text.re_compile("^\\.{1,2}Procedure[ \\t]*$")
   titles.result      = text.re_compile("^\\.{1,2}(?:Verification|Results?)[ \\t]*$")
   titles.trouble     = text.re_compile("^\\.{1,2}(?:Troubleshooting|Troubleshooting steps?)[ \\t]*$")
   titles.postreq     = text.re_compile("^\\.{1,2}Next steps?[ \\t]*$")

--- a/test/BlockTitle.bats
+++ b/test/BlockTitle.bats
@@ -12,6 +12,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore table cells that have similar syntax to block titles" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_table_cells.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Ignore supported block titles in procedure modules" {
   run run_vale "$BATS_TEST_FILENAME" ignore_procedue_titles.adoc
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Fixes issue #74.

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [ ] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
