### PR TITLE
Report content after unsupported block titles

### DIFF
--- a/fixtures/TaskStep/ignore_block_titles.adoc
+++ b/fixtures/TaskStep/ignore_block_titles.adoc
@@ -1,0 +1,15 @@
+// Valid block titles in a procedure:
+:_mod-docs-content-type: PROCEDURE
+
+.Procedure
+
+. A valid step.
++
+.A supported block title
+|===
+|A table cell
+|===
+
+.Result
+
+Valid text.

--- a/fixtures/TaskStep/report_block_titles.adoc
+++ b/fixtures/TaskStep/report_block_titles.adoc
@@ -1,0 +1,13 @@
+// Valid block titles in a procedure:
+:_mod-docs-content-type: PROCEDURE
+
+.Procedure
+
+. A valid step.
++
+.A supported block title
+|===
+|A table cell
+|===
+
+An invalid line.

--- a/styles/AsciiDocDITA/TaskStep.yml
+++ b/styles/AsciiDocDITA/TaskStep.yml
@@ -8,7 +8,7 @@ script: |
   text              := import("text")
   matches           := []
 
-  r_any_title       := text.re_compile("^(?:={2,}[ \\t]+|\\.{1,2})[^ \\t.].*$")
+  r_any_title       := text.re_compile("^\\.{1,2}[^ \\t.].*$")
   r_attribute_list  := text.re_compile("^\\[(?:|[\\w.#%{,\"'].*)\\][ \\t]*$")
   r_attribute       := text.re_compile("^:!?\\S[^:]*:")
   r_comment_block   := text.re_compile("^/{4,}\\s*$")
@@ -21,6 +21,7 @@ script: |
   r_other_block     := text.re_compile("^(?:\\.{4,}|-{4,}|={4,}|-{2})[ \\t]*$")
   r_procedure       := text.re_compile("^(?:={2,}[ \\t]+|\\.{1,2})Procedure[ \\t]*$")
   r_step            := text.re_compile("^[ \\t]*[\\*-.]+[ \\t]+\\S.*$")
+  r_supported_title := text.re_compile("^\\.{1,2}(?:Prerequisites?|Procedure|Verification|Results?|Troubleshooting|Troubleshooting steps?|Next steps?|Additional resources)[ \\t]*$")
 
   document          := text.split(text.trim_suffix(scope, "\n"), "\n")
 
@@ -66,9 +67,8 @@ script: |
 
     if ! in_procedure { continue }
 
-    if r_any_title.match(line) {
-      break
-    }
+    if r_supported_title.match(line) { break }
+    if r_any_title.match(line) { continue }
 
     if in_step {
       if r_other_block.match(line) {

--- a/test/TaskStep.bats
+++ b/test/TaskStep.bats
@@ -24,6 +24,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore block titles" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_block_titles.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Ignore valid lines with all content variations" {
   run run_vale "$BATS_TEST_FILENAME" ignore_valid_lines.adoc
   [ "$status" -eq 0 ]
@@ -62,4 +68,11 @@ load test_helper
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 1 ]
   [ "${lines[0]}" = "report_invalid_callout.adoc:12:1:AsciiDocDITA.TaskStep:Content other than a single list cannot be mapped to DITA tasks." ]
+}
+
+@test "Report content after unsupported block titles" {
+  run run_vale "$BATS_TEST_FILENAME" report_block_titles.adoc
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 1 ]
+  [ "${lines[0]}" = "report_block_titles.adoc:13:1:AsciiDocDITA.TaskStep:Content other than a single list cannot be mapped to DITA tasks." ]
 }


### PR DESCRIPTION
The `TaskStep` rule incorrectly failed to validate content that followed an unsupported block title in a procedure.

### Example AsciiDoc code

```asciidoc
:_mod-docs-content-type: PROCEDURE

.Procedure
. A valid step.
+
.A supported block title
|===
|A table cell
|===

An invalid line.
```

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [ ] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
