### PR TITLE
Add a rule to report attributes inside of links

### DIFF
--- a/styles/AsciiDocDITA/LinkAttribute.yml
+++ b/styles/AsciiDocDITA/LinkAttribute.yml
@@ -1,0 +1,11 @@
+# Report links that contain an attribute reference.
+---
+extends: existence
+message: "Attribute references inside of links cannot be converted to DITA."
+level: warning
+scope: raw
+nonword: true
+tokens:
+  - '(?:|link:|<)(?:|\+\+)(?:https?|file|ftp|irc)://[^ \t\[\]]*\{(?:[0-9A-Za-z][0-9A-Za-z-]*|set:.+?|counter2?:.+?)\}[^ \t\[\]]*(?:|\+\+)(?:|\[.*?\])>?'
+  - '(?:link:|<)(?:|\+\+)\{(?:[0-9A-Za-z][0-9A-Za-z-]*|set:.+?|counter2?:.+?)\}[^ \t\[\]]*(?:|\+\+)(?:|\[.*?\])>?'
+  - '(?:link:|<)(?:|\+\+)#[^ \t\[\]]*\{(?:[0-9A-Za-z][0-9A-Za-z-]*|set:.+?|counter2?:.+?)\}[^ \t\[\]]*(?:|\+\+)(?:|\[.*?\])>?'


### PR DESCRIPTION
Fixes issue #87.

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [ ] The new code comes with the corresponding fixtures and test cases
- [ ] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [ ] The new code passes all tests (run `make test` in the project directory)
