### PR TITLE
Issue #89: Recognize content type separated by more than one space

### DIFF
--- a/styles/AsciiDocDITA/BlockTitle.yml
+++ b/styles/AsciiDocDITA/BlockTitle.yml
@@ -15,7 +15,7 @@ script: |
   r_comment_block   := text.re_compile("^/{4,}\\s*$")
   r_comment_line    := text.re_compile("^(//|//[^/].*)$")
   r_conditional     := text.re_compile("^(?:ifn?def|ifeval|endif)::\\S*\\[.*\\][ \\t]*$")
-  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t](?i:procedure)")
+  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:procedure)")
   r_empty_line      := text.re_compile("^[ \\t]*$")
   r_example_block   := text.re_compile("^\\[example\\][ \\t]*$")
   r_example_delim   := text.re_compile("^={4,}[ \\t]*$")

--- a/styles/AsciiDocDITA/TaskDuplicate.yml
+++ b/styles/AsciiDocDITA/TaskDuplicate.yml
@@ -10,7 +10,7 @@ script: |
 
   r_comment_line    := text.re_compile("^(//|//[^/].*)$")
   r_comment_block   := text.re_compile("^/{4,}\\s*$")
-  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t](?i:procedure)")
+  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:procedure)")
 
   titles            := {}
   titles.prereq      = text.re_compile("^\\.{1,2}Prerequisites?[ \\t]*$")

--- a/styles/AsciiDocDITA/TaskExample.yml
+++ b/styles/AsciiDocDITA/TaskExample.yml
@@ -14,7 +14,7 @@ script: |
   r_comment_line     := text.re_compile("^(//|//[^/].*)$")
   r_code_block       := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
   r_conditional      := text.re_compile("^(?:ifn?def|ifeval|endif)::\\S*\\[.*\\][ \\t]*$")
-  r_content_type     := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t](?i:procedure)")
+  r_content_type     := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:procedure)")
   r_empty_line       := text.re_compile("^[ \\t]*$")
   r_example_block    := text.re_compile("^\\[example\\][ \\t]*$")
   r_example_delim    := text.re_compile("^={4,}[ \\t]*$")

--- a/styles/AsciiDocDITA/TaskSection.yml
+++ b/styles/AsciiDocDITA/TaskSection.yml
@@ -10,7 +10,7 @@ script: |
 
   r_comment_line    := text.re_compile("^(//|//[^/].*)$")
   r_comment_block   := text.re_compile("^/{4,}\\s*$")
-  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t](?i:procedure)")
+  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:procedure)")
   r_section         := text.re_compile("^={2,}[ \\t]\\S.*$")
 
   document          := text.split(text.trim_suffix(scope, "\n"), "\n")

--- a/styles/AsciiDocDITA/TaskStep.yml
+++ b/styles/AsciiDocDITA/TaskStep.yml
@@ -14,7 +14,7 @@ script: |
   r_comment_block   := text.re_compile("^/{4,}\\s*$")
   r_comment_line    := text.re_compile("^(//|//[^/].*)$")
   r_conditional     := text.re_compile("^(?:ifn?def|ifeval|endif)::\\S*\\[.*\\][ \\t]*$")
-  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t](?i:procedure)")
+  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:procedure)")
   r_dlist           := text.re_compile("^[ \\t]*\\S.*?(?::{2,4}|;;)(?:|[ \\t]+.*)$")
   r_empty_line      := text.re_compile("^[ \\t]*$")
   r_list_continue   := text.re_compile("^\\+[ \\t]*$")

--- a/styles/AsciiDocDITA/TaskTitle.yml
+++ b/styles/AsciiDocDITA/TaskTitle.yml
@@ -14,7 +14,7 @@ script: |
   r_comment_block   := text.re_compile("^/{4,}\\s*$")
   r_comment_line    := text.re_compile("^(//|//[^/].*)$")
   r_conditional     := text.re_compile("^(?:ifn?def|ifeval|endif)::\\S*\\[.*\\][ \\t]*$")
-  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t](?i:procedure)")
+  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:procedure)")
   r_example_block   := text.re_compile("^\\[example\\][ \\t]*$")
   r_example_delim   := text.re_compile("^={4,}[ \\t]*$")
   r_image           := text.re_compile("^image::(?:\\S|\\S.*\\S)\\[.*\\][ \\t]*$")


### PR DESCRIPTION
Fixes issue #89.

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [ ] The new code comes with the corresponding fixtures and test cases
- [ ] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
