### PR TITLE
Ensure that RelatedLinks report attribute lists other than `[role="_additional-resources"]`

### DIFF
--- a/styles/AsciiDocDITA/RelatedLinks.yml
+++ b/styles/AsciiDocDITA/RelatedLinks.yml
@@ -21,6 +21,7 @@ script: |
   r_inline_link     := text.re_compile("^[ \\t]*[\\*-][ \\t]+(?:|link:|<)(?:|\\+\\+)(?:https?|file|ftp|irc)://[^ \\t\\[\\]]+(?:|\\+\\+)(?:|\\[.*?\\])>?[ \\t]*$")
   r_inline_xref     := text.re_compile("^[ \\t]*[\\*-][ \\t]+<<[A-Za-z0-9/.:{].*?>>[ \\t]*$")
   r_link_macro      := text.re_compile("^[ \\t]*[\\*-][ \\t]+(?:link|mailto):(?:|[^: \\t\\[][^: \\t\\[]*)\\[.*?\\][ \\t]*$")
+  r_role_attribute  := text.re_compile("^\\[role=['\\x22]_additional-resources['\\x22]\\][ \\t]*$")
   r_xref_macro      := text.re_compile("^[ \\t]*[\\*-][ \\t]+xref:[A-Za-z0-9/.:{].*?\\[.*?\\][ \\t]*$")
 
   document          := text.split(text.trim_suffix(scope, "\n"), "\n")
@@ -54,8 +55,11 @@ script: |
 
     if r_empty_line.match(line) { continue }
     if r_attribute.match(line) { continue }
-    if r_attribute_list.match(line) { continue }
     if r_conditional.match(line) { continue }
+
+    if r_attribute_list.match(line) && r_role_attribute.match(line) {
+      continue
+    }
 
     if r_include.match(line) && is_assembly {
       continue


### PR DESCRIPTION
Because `[role="_additional-resources"]` attribute list is commonly assigned to the section introducing Additional resources, the `RelatedLinks` excludes these from the report. However, the previous implementation just skipped all attribute lists and therefore  failed to report those that introduce other blocks or admonitions. This update ensures that other attribute lists are reported correctly.

### Example AsciiDoc Code

```asciidoc
[role="_additional-resources"]
.Additional resources

* link:https://example.com[example link]

[NOTE]
====
An admonition.
====
```

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [ ] The new code comes with the corresponding fixtures and test cases
- [ ] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [ ] The new code passes all tests (run `make test` in the project directory)
