### PR TITLE
Issue #98: Ignore entity references in code blocks

### DIFF
--- a/fixtures/EntityReference/ignore_code_blocks.adoc
+++ b/fixtures/EntityReference/ignore_code_blocks.adoc
@@ -1,0 +1,55 @@
+// HTML character entity references in code blocks:
+
+....
+===============================================
+Horizontal ellipsis: &hellip;
+Middle dot:          &middot;
+....
+
+[literal]
+....
+===============================================
+Horizontal ellipsis: &hellip;
+Middle dot:          &middot;
+....
+
+[literal,subs="+quotes"]
+....
+===============================================
+Horizontal ellipsis: &hellip;
+Middle dot:          &middot;
+....
+
+[subs="+quotes"]
+....
+===============================================
+Horizontal ellipsis: &hellip;
+Middle dot:          &middot;
+....
+
+----
+===============================================
+Horizontal ellipsis: &hellip;
+Middle dot:          &middot;
+----
+
+[source]
+----
+===============================================
+Horizontal ellipsis: &hellip;
+Middle dot:          &middot;
+----
+
+[source,asciidoc]
+----
+===============================================
+Horizontal ellipsis: &hellip;
+Middle dot:          &middot;
+----
+
+[source,subs="+quotes"]
+----
+===============================================
+Horizontal ellipsis: &hellip;
+Middle dot:          &middot;
+----

--- a/styles/AsciiDocDITA/EntityReference.yml
+++ b/styles/AsciiDocDITA/EntityReference.yml
@@ -8,6 +8,7 @@ script: |
   text               := import("text")
   matches            := []
 
+  r_code_block       := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
   r_comment_line     := text.re_compile("^(//|//[^/].*)$")
   r_comment_block    := text.re_compile("^/{4,}\\s*$")
   r_entity_reference := text.re_compile("&[a-zA-Z][a-zA-Z0-9]*;")
@@ -15,6 +16,7 @@ script: |
 
   document           := text.split(text.trim_suffix(scope, "\n"), "\n")
 
+  in_code_block      := false
   in_comment_block   := false
   start              := 0
   end                := 0
@@ -34,6 +36,17 @@ script: |
     }
     if in_comment_block { continue }
     if r_comment_line.match(line) { continue }
+
+    if r_code_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_code_block {
+        in_code_block = delimiter
+      } else if in_code_block == delimiter {
+        in_code_block = false
+      }
+      continue
+    }
+    if in_code_block { continue }
 
     for i, entry in r_entity_reference.find(line, -1) {
       if ! r_supported_entity.match(entry[0].text) {

--- a/test/EntityReference.bats
+++ b/test/EntityReference.bats
@@ -24,6 +24,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore code blocks with replacements disabled" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_code_blocks.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Report unsupported character entity references" {
   run run_vale "$BATS_TEST_FILENAME" report_entity_references.adoc
   [ "$status" -ne 0 ]


### PR DESCRIPTION
Fixes issue #98.

Note that while AsciiDoc does not replace HTML and XML entities inside of code blocks by default, users may enable this replacement by [customizing the substitutions](https://docs.asciidoctor.org/asciidoc/latest/subs/apply-subs-to-blocks/) in the attribute list:

```asciidoc
[subs="+replacements"]
----
===============================================
Horizontal ellipsis: &hellip;
Middle dot:          &middot;
----
```

In addition to allowing users to prepend to, append to, or subtract from the substitution list, it also allows users to overwrite the list, which can also enable some substitutions previously disabled for code blocks, including entity replacements:

```asciidoc
[subs="quotes"]
----
===============================================
Horizontal ellipsis: &hellip;
Middle dot:          &middot;
----
```

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [ ] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
