### PR TITLE
Do not report bullet points with an attribute reference

### DIFF
--- a/fixtures/RelatedLinks/ignore_attribute_references.adoc
+++ b/fixtures/RelatedLinks/ignore_attribute_references.adoc
@@ -1,0 +1,4 @@
+// Valid attribute references:
+.Additional resources
+
+* {LinkAttribute}

--- a/styles/AsciiDocDITA/RelatedLinks.yml
+++ b/styles/AsciiDocDITA/RelatedLinks.yml
@@ -11,6 +11,7 @@ script: |
   r_add_resources   := text.re_compile("^(?:={2,}[ \\t]+|\\.{1,2})Additional resources[ \\t]*$")
   r_any_title       := text.re_compile("^(?:={2,}[ \\t]+|\\.{1,2})[^ \\t.].*$")
   r_attribute       := text.re_compile("^:!?\\S[^:]*:")
+  r_attribute_ref   := text.re_compile("^[ \\t]*[\\*-][ \\t]+\\{(?:[0-9A-Za-z_][0-9A-Za-z_-]*|set:.+?|counter2?:.+?)\\}[ \\t]*$")
   r_comment_block   := text.re_compile("^/{4,}\\s*$")
   r_comment_line    := text.re_compile("^(//|//[^/].*)$")
   r_conditional     := text.re_compile("^(?:ifn?def|ifeval|endif)::\\S*\\[.*\\][ \\t]*$")
@@ -78,7 +79,8 @@ script: |
     }
 
     if r_link_macro.match(line) || r_inline_link.match(line) ||
-       r_xref_macro.match(line) || r_inline_xref.match(line) {
+       r_xref_macro.match(line) || r_inline_xref.match(line) ||
+       r_attribute_ref.match(line) {
       continue
     }
 

--- a/test/RelatedLinks.bats
+++ b/test/RelatedLinks.bats
@@ -18,6 +18,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore supported attribute references" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_attribute_references.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Ignore conditional directives" {
   run run_vale "$BATS_TEST_FILENAME" ignore_conditionals.adoc
   [ "$status" -eq 0 ]


### PR DESCRIPTION
It is perfectly valid to define an entire link as a custom AsciiDoc attribute and then use that attribute reference in the related links. The `RelatedLinks` rule should not report these as problematic.

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [ ] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
