### PR TITLE
Issue #112: Do not report valid example blocks

### DIFF
--- a/fixtures/TaskStep/ignore_example_block.adoc
+++ b/fixtures/TaskStep/ignore_example_block.adoc
@@ -1,0 +1,11 @@
+// Valid example block in a procedure:
+:_mod-docs-content-type: PROCEDURE
+
+.Procedure
+
+. A valid step.
+
+.A valid example title
+====
+Valid text.
+====

--- a/fixtures/TaskStep/report_admonitions.adoc
+++ b/fixtures/TaskStep/report_admonitions.adoc
@@ -1,0 +1,12 @@
+// An invalid admonition in a procedure:
+:_mod-docs-content-type: PROCEDURE
+
+.Procedure
+
+. A valid step.
+
+.An invalid admonition
+[NOTE]
+====
+An invalid admonition.
+====

--- a/styles/AsciiDocDITA/TaskStep.yml
+++ b/styles/AsciiDocDITA/TaskStep.yml
@@ -8,6 +8,7 @@ script: |
   text              := import("text")
   matches           := []
 
+  r_admonition      := text.re_compile("^\\[(?:NOTE|TIP|IMPORTANT|WARNING|CAUTION)\\][ \\t]*$")
   r_any_title       := text.re_compile("^\\.{1,2}[^ \\t.].*$")
   r_attribute_list  := text.re_compile("^\\[(?:|[\\w.#%{,\"'].*)\\][ \\t]*$")
   r_attribute       := text.re_compile("^:!?\\S[^:]*:")
@@ -17,6 +18,7 @@ script: |
   r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:procedure)")
   r_dlist           := text.re_compile("^[ \\t]*\\S.*?(?::{2,4}|;;)(?:|[ \\t]+.*)$")
   r_empty_line      := text.re_compile("^[ \\t]*$")
+  r_example_delim   := text.re_compile("^={4,}[ \\t]*$")
   r_list_continue   := text.re_compile("^\\+[ \\t]*$")
   r_other_block     := text.re_compile("^(?:\\.{4,}|-{4,}|={4,}|-{2}|\\|={3,})[ \\t]*$")
   r_procedure       := text.re_compile("^(?:={2,}[ \\t]+|\\.{1,2})Procedure[ \\t]*$")
@@ -56,9 +58,11 @@ script: |
       continue
     }
 
-    if r_attribute.match(line) { continue }
-    if r_attribute_list.match(line) { continue }
     if r_conditional.match(line) { continue }
+    if r_attribute.match(line) { continue }
+    if r_attribute_list.match(line) && ! r_admonition.match(line) {
+      continue
+    }
 
     if r_procedure.match(line) {
       in_procedure = true
@@ -111,6 +115,8 @@ script: |
     }
 
     if in_step { continue }
+
+    if r_example_delim.match(line) { break }
 
     matches = append(matches, {begin: start, end: start + end - 1})
 

--- a/test/TaskStep.bats
+++ b/test/TaskStep.bats
@@ -30,6 +30,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore valid example blocks" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_example_block.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Ignore valid lines with all content variations" {
   run run_vale "$BATS_TEST_FILENAME" ignore_valid_lines.adoc
   [ "$status" -eq 0 ]
@@ -75,4 +81,11 @@ load test_helper
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 1 ]
   [ "${lines[0]}" = "report_block_titles.adoc:13:1:AsciiDocDITA.TaskStep:Content other than a single list cannot be mapped to DITA tasks." ]
+}
+
+@test "Report admonitions after steps" {
+  run run_vale "$BATS_TEST_FILENAME" report_admonitions.adoc
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 1 ]
+  [ "${lines[0]}" = "report_admonitions.adoc:9:1:AsciiDocDITA.TaskStep:Content other than a single list cannot be mapped to DITA tasks." ]
 }


### PR DESCRIPTION
Fixes issue #112.

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [ ] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
