### PR TITLE
Do not count the same example block twice

### DIFF
--- a/styles/AsciiDocDITA/TaskExample.yml
+++ b/styles/AsciiDocDITA/TaskExample.yml
@@ -23,6 +23,7 @@ script: |
   document           := text.split(text.trim_suffix(scope, "\n"), "\n")
 
   expect_admonition  := false
+  expect_example     := false
   in_comment_block   := false
   in_code_block      := false
   in_example_block   := false
@@ -86,6 +87,10 @@ script: |
           expect_admonition = false
           continue
         }
+        if expect_example {
+          expect_example = false
+          continue
+        }
 
         count++
 
@@ -105,10 +110,12 @@ script: |
         matches = append(matches, {begin: start, end: start + end - 1})
       }
 
+      expect_example = true
       continue
     }
 
     expect_admonition = false
+    expect_example = false
   }
 
   if ! is_procedure {


### PR DESCRIPTION
In AsciiDocs, there are two distinct ways of marking up example blocks: [by using the `[example]` attribute list](https://docs.asciidoctor.org/asciidoc/latest/blocks/example-blocks/#example-style-syntax) above any block of text, or [by using the delimited example block](https://docs.asciidoctor.org/asciidoc/latest/blocks/example-blocks/#delimited). Unfortunately, when both are used at the same time to mark up a single example block, the `TaskExample` rule incorrectly reports it as a duplicate:

```
 file.adoc
 4:1  error  Examples are allowed only once  AsciiDocDITA.TaskExample 
             in DITA tasks.
```
### Example AsciiDoc code

```asciidoc
:_mod-docs-content-type: PROCEDURE

[example]
====
An example block.
====
```

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [ ] The new code comes with the corresponding fixtures and test cases
- [ ] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [ ] The new code passes all tests (run `make test` in the project directory)
