### PR TITLE
Do not report BlockTitle warnings for content in code blocks

### DIFF
--- a/fixtures/BlockTitle/ignore_code_blocks.adoc
+++ b/fixtures/BlockTitle/ignore_code_blocks.adoc
@@ -1,0 +1,6 @@
+// Lines with similar synatx to block titles inside of code blocks:
+
+[source,terminal]
+----
+./run-command.sh .
+----

--- a/styles/AsciiDocDITA/BlockTitle.yml
+++ b/styles/AsciiDocDITA/BlockTitle.yml
@@ -12,6 +12,7 @@ script: |
   r_attribute_list  := text.re_compile("^\\[(?:|[\\w.#%{,\"'].*)\\][ \\t]*$")
   r_attribute       := text.re_compile("^:!?\\S[^:]*:")
   r_block_title     := text.re_compile("^\\.{1,2}[^ \\t.].*$")
+  r_code_block      := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
   r_comment_block   := text.re_compile("^/{4,}\\s*$")
   r_comment_line    := text.re_compile("^(//|//[^/].*)$")
   r_conditional     := text.re_compile("^(?:ifn?def|ifeval|endif)::\\S*\\[.*\\][ \\t]*$")
@@ -26,6 +27,7 @@ script: |
 
   document          := text.split(text.trim_suffix(scope, "\n"), "\n")
 
+  in_code_block     := false
   in_comment_block  := false
   is_procedure      := false
   expect_block      := false
@@ -47,6 +49,17 @@ script: |
     }
     if in_comment_block { continue }
     if r_comment_line.match(line) { continue }
+
+    if r_code_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_code_block {
+        in_code_block = delimiter
+      } else if in_code_block == delimiter {
+        in_code_block = false
+      }
+      continue
+    }
+    if in_code_block { continue }
 
     if r_content_type.match(line) {
       is_procedure = true
@@ -75,7 +88,10 @@ script: |
 
     if expect_block {
       matches = append(matches, expect_block)
+      expect_block = false
     }
+  }
 
-    expect_block = false
+  if expect_block {
+    matches = append(matches, expect_block)
   }

--- a/test/BlockTitle.bats
+++ b/test/BlockTitle.bats
@@ -6,6 +6,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore block titles inside of code blocks" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_code_blocks.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Ignore steps that have similar syntax to block titles" {
   run run_vale "$BATS_TEST_FILENAME" ignore_steps.adoc
   [ "$status" -eq 0 ]


### PR DESCRIPTION
The `BlockTitle` rule  incorrectly reports contents inside of code blocks. This pull request ensures that content in code blocks is completely ignored.

```
 file.adoc
 3:1  warning  Block titles can only be        AsciiDocDITA.BlockTitle  
               assigned to examples, figures,                           
               and tables in DITA.
```

### Example AsciiDoc code

```asciidoc
[source,terminal]
----
./run-command.sh .
----
```

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [ ] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
