### PR TITLE
Do not report TaskTitle warnings for content in code blocks

### DIFF
--- a/fixtures/TaskTitle/ignore_code_blocks.adoc
+++ b/fixtures/TaskTitle/ignore_code_blocks.adoc
@@ -1,0 +1,7 @@
+// Lines with similar synatx to block titles inside of code blocks:
+:_mod-docs-content-type: PROCEDURE
+
+[source,terminal]
+----
+./run-command.sh .
+----

--- a/styles/AsciiDocDITA/TaskTitle.yml
+++ b/styles/AsciiDocDITA/TaskTitle.yml
@@ -11,6 +11,7 @@ script: |
   r_attribute_list  := text.re_compile("^\\[(?:|[\\w.#%{,\"'].*)\\][ \\t]*$")
   r_attribute       := text.re_compile("^:!?\\S[^:]*:")
   r_block_title     := text.re_compile("^\\.{1,2}[^ \\t.].*$")
+  r_code_block      := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
   r_comment_block   := text.re_compile("^/{4,}\\s*$")
   r_comment_line    := text.re_compile("^(//|//[^/].*)$")
   r_conditional     := text.re_compile("^(?:ifn?def|ifeval|endif)::\\S*\\[.*\\][ \\t]*$")
@@ -24,6 +25,7 @@ script: |
 
   document          := text.split(text.trim_suffix(scope, "\n"), "\n")
 
+  in_code_block     := false
   in_comment_block  := false
   is_procedure      := false
   is_list_continue  := false
@@ -46,6 +48,17 @@ script: |
     }
     if in_comment_block { continue }
     if r_comment_line.match(line) { continue }
+
+    if r_code_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_code_block {
+        in_code_block = delimiter
+      } else if in_code_block == delimiter {
+        in_code_block = false
+      }
+      continue
+    }
+    if in_code_block { continue }
 
     if r_content_type.match(line) {
       is_procedure = true

--- a/test/TaskTitle.bats
+++ b/test/TaskTitle.bats
@@ -6,6 +6,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore block titles inside of code blocks" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_code_blocks.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Ignore block titles in other content types" {
   run run_vale "$BATS_TEST_FILENAME" ignore_other_modules.adoc
   [ "$status" -eq 0 ]


### PR DESCRIPTION
The `TaskTitle` rule incorrectly reports contents inside of code blocks. This pull request ensures that content in code blocks is completely ignored.

```
 file.adoc
 5:1  warning  Unsupported titles cannot be    AsciiDocDITA.TaskTitle  
               mapped to DITA tasks.
```

### Example AsciiDoc code

```asciidoc
:_mod-docs-content-type: PROCEDURE

[source,terminal]
----
./run-command.sh .
----
```

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [ ] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
