### PR TITLE
Do not report SidebarBlock warnings for content in code blocks

### DIFF
--- a/fixtures/SidebarBlock/ignore_code_blocks.adoc
+++ b/fixtures/SidebarBlock/ignore_code_blocks.adoc
@@ -1,0 +1,7 @@
+// Lines with similar synatx to sidebar blocks inside of code blocks:
+
+[source,terminal]
+----
+A code block.
+*************
+----

--- a/fixtures/SidebarBlock/ignore_comments.adoc
+++ b/fixtures/SidebarBlock/ignore_comments.adoc
@@ -6,3 +6,12 @@
 //****
 //A paragraph.
 //****
+
+////
+[sidebar]
+A paragraph.
+
+****
+A paragraph.
+****
+////

--- a/styles/AsciiDocDITA/SidebarBlock.yml
+++ b/styles/AsciiDocDITA/SidebarBlock.yml
@@ -1,10 +1,54 @@
 # Report that sidebars are not supported.
 ---
-extends: existence
+extends: script
 message: "Sidebars are not supported in DITA."
 level: warning
 scope: raw
-nonword: true
-tokens:
-  - '^\[sidebar\b[^\n\]]*?\]'
-  - '^\*{4,}[ \t]*$'
+script: |
+  text              := import("text")
+  matches           := []
+
+  r_code_block      := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
+  r_comment_block   := text.re_compile("^/{4,}\\s*$")
+  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_sidebar_block   := text.re_compile("^\\[sidebar\\b[^\\]]*?\\][ \\t]*$")
+  r_sidebar_delim   := text.re_compile("^\\*{4,}[ \\t]*$")
+
+  document          := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  in_code_block     := false
+  in_comment_block  := false
+  start             := 0
+  end               := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_code_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_code_block {
+        in_code_block = delimiter
+      } else if in_code_block == delimiter {
+        in_code_block = false
+      }
+      continue
+    }
+    if in_code_block { continue }
+
+    if r_sidebar_block.match(line) || r_sidebar_delim.match(line) {
+      matches = append(matches, {begin: start, end: start + end - 1})
+    }
+  }

--- a/test/SidebarBlock.bats
+++ b/test/SidebarBlock.bats
@@ -1,7 +1,13 @@
 load test_helper
 
-@test "Ignore sidebars in single-line comments" {
+@test "Ignore sidebars inside of line and block comments" {
   run run_vale "$BATS_TEST_FILENAME" ignore_comments.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore sidebars inside of code blocks" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_code_blocks.adoc
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "" ]
 }


### PR DESCRIPTION
The `SidebarBlock` rule incorrectly reports contents inside of code blocks. This pull request ensures that content in code blocks is completely ignored.

```
 file.adoc
 4:1  warning  Sidebars are not supported in   AsciiDocDITA.SidebarBlock 
               DITA.
```

### Example AsciiDoc code

```asciidoc
[source,terminal]
----
A code block.
*************
----
```

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [ ] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
