### PR TITLE
Link to documentation from individual rules

### DIFF
--- a/styles/AsciiDocDITA/AdmonitionTitle.yml
+++ b/styles/AsciiDocDITA/AdmonitionTitle.yml
@@ -3,6 +3,7 @@
 extends: script
 message: "Admonition titles are not supported in DITA."
 level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
 scope: raw
 script: |
   text               := import("text")

--- a/styles/AsciiDocDITA/AttributeReference.yml
+++ b/styles/AsciiDocDITA/AttributeReference.yml
@@ -3,6 +3,7 @@
 extends: existence
 message: "%s"
 level: suggestion
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#suggestions
 scope: raw
 nonword: true
 tokens:

--- a/styles/AsciiDocDITA/AuthorLine.yml
+++ b/styles/AsciiDocDITA/AuthorLine.yml
@@ -3,6 +3,7 @@
 extends: script
 message: "Author lines are not supported for topics."
 level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
 scope: raw
 script: |
   text              := import("text")

--- a/styles/AsciiDocDITA/BlockTitle.yml
+++ b/styles/AsciiDocDITA/BlockTitle.yml
@@ -3,6 +3,7 @@
 extends: script
 message: "Block titles can only be assigned to examples, figures, and tables in DITA."
 level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
 scope: raw
 script: |
   text              := import("text")

--- a/styles/AsciiDocDITA/ConditionalCode.yml
+++ b/styles/AsciiDocDITA/ConditionalCode.yml
@@ -3,6 +3,7 @@
 extends: existence
 message: "%s"
 level: suggestion
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#suggestions
 scope: raw
 nonword: true
 tokens:

--- a/styles/AsciiDocDITA/ContentType.yml
+++ b/styles/AsciiDocDITA/ContentType.yml
@@ -3,6 +3,7 @@
 extends: occurrence
 message: "The '_mod-docs-content-type' attribute definition is missing."
 level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
 scope: raw
 min: 1
 token: '(?:^|[\n\r]):_(?:mod-docs-content|content|module)-type:[ \t]+\S'

--- a/styles/AsciiDocDITA/DiscreteHeading.yml
+++ b/styles/AsciiDocDITA/DiscreteHeading.yml
@@ -3,6 +3,7 @@
 extends: existence
 message: "Discrete headings are not supported in DITA."
 level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
 scope: raw
 nonword: true
 tokens:

--- a/styles/AsciiDocDITA/EntityReference.yml
+++ b/styles/AsciiDocDITA/EntityReference.yml
@@ -3,6 +3,7 @@
 extends: script
 message: "HTML character entity references are not supported in DITA."
 level: error
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#errors
 scope: raw
 script: |
   text               := import("text")

--- a/styles/AsciiDocDITA/EquationFormula.yml
+++ b/styles/AsciiDocDITA/EquationFormula.yml
@@ -3,6 +3,7 @@
 extends: existence
 message: "Equations and formulas are not implemented."
 level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
 scope: raw
 nonword: true
 tokens:

--- a/styles/AsciiDocDITA/ExampleBlock.yml
+++ b/styles/AsciiDocDITA/ExampleBlock.yml
@@ -3,6 +3,7 @@
 extends: script
 message: "Examples can not be inside of other blocks in DITA."
 level: error
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#errors
 scope: raw
 script: |
   text               := import("text")

--- a/styles/AsciiDocDITA/IncludeDirective.yml
+++ b/styles/AsciiDocDITA/IncludeDirective.yml
@@ -3,6 +3,7 @@
 extends: existence
 message: "%s"
 level: suggestion
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#suggestions
 scope: raw
 nonword: true
 tokens:

--- a/styles/AsciiDocDITA/LineBreak.yml
+++ b/styles/AsciiDocDITA/LineBreak.yml
@@ -3,6 +3,7 @@
 extends: existence
 message: "Hard line breaks are not supported in DITA."
 level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
 scope: raw
 nonword: true
 tokens:

--- a/styles/AsciiDocDITA/LinkAttribute.yml
+++ b/styles/AsciiDocDITA/LinkAttribute.yml
@@ -3,6 +3,7 @@
 extends: script
 message: "Attribute references inside of links cannot be converted to DITA."
 level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
 scope: raw
 script: |
   text               := import("text")

--- a/styles/AsciiDocDITA/NestedSection.yml
+++ b/styles/AsciiDocDITA/NestedSection.yml
@@ -3,6 +3,7 @@
 extends: existence
 message: "Level 2, 3, 4, and 5 sections are not supported in DITA."
 level: error
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#errors
 scope: raw
 nonword: true
 tokens:

--- a/styles/AsciiDocDITA/PageBreak.yml
+++ b/styles/AsciiDocDITA/PageBreak.yml
@@ -3,6 +3,7 @@
 extends: existence
 message: "Page breaks are not supported in DITA."
 level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
 scope: raw
 nonword: true
 tokens:

--- a/styles/AsciiDocDITA/RelatedLinks.yml
+++ b/styles/AsciiDocDITA/RelatedLinks.yml
@@ -3,6 +3,7 @@
 extends: script
 message: "Content other than links cannot be mapped to DITA related-links."
 level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
 scope: raw
 script: |
   text              := import("text")

--- a/styles/AsciiDocDITA/ShortDescription.yml
+++ b/styles/AsciiDocDITA/ShortDescription.yml
@@ -4,6 +4,7 @@
 extends: occurrence
 message: "Assign [role=\"_abstract\"] to a paragraph to use it as <shortdesc> in DITA."
 level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
 scope: raw
 min: 1
 token: '(?:^|[\n\r])\[role="_abstract"\]'

--- a/styles/AsciiDocDITA/SidebarBlock.yml
+++ b/styles/AsciiDocDITA/SidebarBlock.yml
@@ -3,6 +3,7 @@
 extends: script
 message: "Sidebars are not supported in DITA."
 level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
 scope: raw
 script: |
   text              := import("text")

--- a/styles/AsciiDocDITA/TableFooter.yml
+++ b/styles/AsciiDocDITA/TableFooter.yml
@@ -3,6 +3,7 @@
 extends: existence
 message: "Table footers are not supported in DITA."
 level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
 scope: raw
 nonword: true
 tokens:

--- a/styles/AsciiDocDITA/TagDirective.yml
+++ b/styles/AsciiDocDITA/TagDirective.yml
@@ -3,6 +3,7 @@
 extends: existence
 message: "%s"
 level: suggestion
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#suggestions
 scope: raw
 nonword: true
 tokens:

--- a/styles/AsciiDocDITA/TaskDuplicate.yml
+++ b/styles/AsciiDocDITA/TaskDuplicate.yml
@@ -3,6 +3,7 @@
 extends: script
 message: "Duplicate titles cannot be mapped to DITA tasks."
 level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
 scope: raw
 script: |
   text              := import("text")

--- a/styles/AsciiDocDITA/TaskExample.yml
+++ b/styles/AsciiDocDITA/TaskExample.yml
@@ -3,6 +3,7 @@
 extends: script
 message: "Examples are allowed only once in DITA tasks."
 level: error
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#errors
 scope: raw
 script: |
   text               := import("text")

--- a/styles/AsciiDocDITA/TaskSection.yml
+++ b/styles/AsciiDocDITA/TaskSection.yml
@@ -3,6 +3,7 @@
 extends: script
 message: "Sections are not allowed in DITA tasks."
 level: error
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#errors
 scope: raw
 script: |
   text              := import("text")

--- a/styles/AsciiDocDITA/TaskStep.yml
+++ b/styles/AsciiDocDITA/TaskStep.yml
@@ -3,6 +3,7 @@
 extends: script
 message: "Content other than a single list cannot be mapped to DITA tasks."
 level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
 scope: raw
 script: |
   text              := import("text")

--- a/styles/AsciiDocDITA/TaskTitle.yml
+++ b/styles/AsciiDocDITA/TaskTitle.yml
@@ -3,6 +3,7 @@
 extends: script
 message: "Unsupported titles cannot be mapped to DITA tasks."
 level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
 scope: raw
 script: |
   text              := import("text")

--- a/styles/AsciiDocDITA/ThematicBreak.yml
+++ b/styles/AsciiDocDITA/ThematicBreak.yml
@@ -3,6 +3,7 @@
 extends: existence
 message: "Thematic breaks are not supported in DITA."
 level: warning
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
 scope: raw
 nonword: true
 tokens:


### PR DESCRIPTION
This was suggested in #121 and is an oversight on my part.

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [ ] The new code comes with the corresponding fixtures and test cases
- [ ] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
