### PR TITLE
Issue #121: Do not report link fragments as RelatedLinks

### DIFF
--- a/fixtures/RelatedLinks/ignore_attribute_references.adoc
+++ b/fixtures/RelatedLinks/ignore_attribute_references.adoc
@@ -2,3 +2,5 @@
 .Additional resources
 
 * {LinkAttribute}
+* {LinkAttribute}[{LinkTextAttribute}]
+* {LinkAttribute}/path#anchor[Link text]

--- a/styles/AsciiDocDITA/RelatedLinks.yml
+++ b/styles/AsciiDocDITA/RelatedLinks.yml
@@ -12,7 +12,7 @@ script: |
   r_add_resources   := text.re_compile("^(?:={2,}[ \\t]+|\\.{1,2})Additional resources[ \\t]*$")
   r_any_title       := text.re_compile("^(?:={2,}[ \\t]+|\\.{1,2})[^ \\t.].*$")
   r_attribute       := text.re_compile("^:!?\\S[^:]*:")
-  r_attribute_ref   := text.re_compile("^[ \\t]*[\\*-][ \\t]+\\{(?:[0-9A-Za-z_][0-9A-Za-z_-]*|set:.+?|counter2?:.+?)\\}[ \\t]*$")
+  r_attribute_ref   := text.re_compile("^[ \\t]*[\\*-][ \\t]+\\{(?:[0-9A-Za-z_][0-9A-Za-z_-]*|set:.+?|counter2?:.+?)\\}(?:|[^\\[\\s]*\\[.*?\\])[ \\t]*$")
   r_comment_block   := text.re_compile("^/{4,}\\s*$")
   r_comment_line    := text.re_compile("^(//|//[^/].*)$")
   r_conditional     := text.re_compile("^(?:ifn?def|ifeval|endif)::\\S*\\[.*\\][ \\t]*$")


### PR DESCRIPTION
Fixes issue #121. While problematic for other reasons, `RelatedLinks` is not the rule that should trip on these.

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [ ] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
