### PR TITLE
Issue #104: Ignore links escaped with inline markup.

### DIFF
--- a/fixtures/LinkAttribute/ignore_escapes.adoc
+++ b/fixtures/LinkAttribute/ignore_escapes.adoc
@@ -9,3 +9,17 @@
 \link:++{DOCUMENT_URL}++[link text]
 
 \link:{BaseURL}/docs/version-{ProductVersion}/title[link text]
+
+https://_{ExampleURL}_:8443/path/_{ProjectName}_Path
+
+https://*{ExampleURL}*:8443/path/_{ProjectName}_Path
+
+https://`{ExampleURL}`:8443/path/_{ProjectName}_Path
+
+https://#{ExampleURL}#:8443/path/_{ProjectName}_Path
+
+https://~{ExampleURL}~:8443/path/_{ProjectName}_Path
+
+https://^{ExampleURL}^:8443/path/_{ProjectName}_Path
+
+https://_{ExampleSubdomain}_.example.com:8443/path/_{ProjectName}_Path

--- a/fixtures/LinkAttribute/report_attribute_references.adoc
+++ b/fixtures/LinkAttribute/report_attribute_references.adoc
@@ -12,3 +12,15 @@ https://example.com/docs/version-{ProductVersion}/title
 <ftp://{SERVER_NAME}/downloads/>
 
 link:{DocumentURL}
+
+https://example.com:8443/path/_{ProjectName}_Path
+
+https://example.com:8443/path/*{ProjectName}*Path
+
+https://example.com:8443/path/`{ProjectName}`Path
+
+https://example.com:8443/path/#{ProjectName}#Path
+
+https://example.com:8443/path/~{ProjectName}~Path
+
+https://example.com:8443/path/^{ProjectName}^Path

--- a/styles/AsciiDocDITA/LinkAttribute.yml
+++ b/styles/AsciiDocDITA/LinkAttribute.yml
@@ -9,10 +9,12 @@ script: |
   text               := import("text")
   matches            := []
 
+  r_attribute_ref    := text.re_compile("\\{(?:[0-9A-Za-z_][0-9A-Za-z_-]*|set:.+?|counter2?:.+?)\\}")
   r_code_block       := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
   r_comment_line     := text.re_compile("^(//|//[^/].*)$")
   r_comment_block    := text.re_compile("^/{4,}\\s*$")
   r_complete_link    := text.re_compile("(?:|link:)(?:|\\+\\+)(?:https?|file|ftp|irc)://[^\\s\\[\\]]*(\\{(?:[0-9A-Za-z_][0-9A-Za-z_-]*|set:.+?|counter2?:.+?)\\})[^\\s\\[\\]]*(?:|\\+\\+)(?:|\\[.*?\\])")
+  r_domain_markup    := text.re_compile("(?:https?|file|ftp|irc):///?[^/]*[_*`#~^][^/]*")
   r_incomplete_link  := text.re_compile("link:(?:|\\+\\+)\\{(?:[0-9A-Za-z_][0-9A-Za-z_-]*|set:.+?|counter2?:.+?)\\}[^\\s\\[\\]]*(?:|\\+\\+)(?:|\\[.*?\\])")
 
   document           := text.split(text.trim_suffix(scope, "\n"), "\n")
@@ -50,12 +52,15 @@ script: |
     if in_code_block { continue }
 
     for i, entry in r_complete_link.find(line, -1) {
-      if (text.has_prefix(text.substr(line, entry[1].begin -1, entry[1].begin), '$')) {
+      if (text.has_prefix(text.substr(line, entry[1].begin - 1, entry[1].begin), '$')) {
         continue
       }
 
       link := entry[0]
       if (link.begin > 0) && text.has_prefix(text.substr(line, link.begin - 1, link.begin), '\\') {
+        continue
+      }
+      if r_domain_markup.match(r_attribute_ref.replace(link.text, "")) {
         continue
       }
 

--- a/test/LinkAttribute.bats
+++ b/test/LinkAttribute.bats
@@ -39,7 +39,7 @@ load test_helper
 @test "Report links with attribute references" {
   run run_vale "$BATS_TEST_FILENAME" report_attribute_references.adoc
   [ "$status" -eq 0 ]
-  [ "${#lines[@]}" -eq 7 ]
+  [ "${#lines[@]}" -eq 13 ]
   [ "${lines[0]}" = "report_attribute_references.adoc:2:1:AsciiDocDITA.LinkAttribute:Attribute references inside of links cannot be converted to DITA." ]
   [ "${lines[1]}" = "report_attribute_references.adoc:4:1:AsciiDocDITA.LinkAttribute:Attribute references inside of links cannot be converted to DITA." ]
   [ "${lines[2]}" = "report_attribute_references.adoc:6:1:AsciiDocDITA.LinkAttribute:Attribute references inside of links cannot be converted to DITA." ]
@@ -47,4 +47,10 @@ load test_helper
   [ "${lines[4]}" = "report_attribute_references.adoc:10:1:AsciiDocDITA.LinkAttribute:Attribute references inside of links cannot be converted to DITA." ]
   [ "${lines[5]}" = "report_attribute_references.adoc:12:2:AsciiDocDITA.LinkAttribute:Attribute references inside of links cannot be converted to DITA." ]
   [ "${lines[6]}" = "report_attribute_references.adoc:14:1:AsciiDocDITA.LinkAttribute:Attribute references inside of links cannot be converted to DITA." ]
+  [ "${lines[7]}" = "report_attribute_references.adoc:16:1:AsciiDocDITA.LinkAttribute:Attribute references inside of links cannot be converted to DITA." ]
+  [ "${lines[8]}" = "report_attribute_references.adoc:18:1:AsciiDocDITA.LinkAttribute:Attribute references inside of links cannot be converted to DITA." ]
+  [ "${lines[9]}" = "report_attribute_references.adoc:20:1:AsciiDocDITA.LinkAttribute:Attribute references inside of links cannot be converted to DITA." ]
+  [ "${lines[10]}" = "report_attribute_references.adoc:22:1:AsciiDocDITA.LinkAttribute:Attribute references inside of links cannot be converted to DITA." ]
+  [ "${lines[11]}" = "report_attribute_references.adoc:24:1:AsciiDocDITA.LinkAttribute:Attribute references inside of links cannot be converted to DITA." ]
+  [ "${lines[12]}" = "report_attribute_references.adoc:26:1:AsciiDocDITA.LinkAttribute:Attribute references inside of links cannot be converted to DITA." ]
 }


### PR DESCRIPTION
Fixes issue #104, specifically the situation where an inline link is not converted to a clickable link by Asciidoctor because of the presence of inline markup in the domain part. Contrary to the initial impression, whether such a link is marked up as inline code has no effect on whether it is resolved or not.

### Example AsciiDoc code

```asciidoc
https://_{ExampleURL}_:8443/path/_{ProjectName}_Path

https://*{ExampleURL}*:8443/path/_{ProjectName}_Path

https://`{ExampleURL}`:8443/path/_{ProjectName}_Path

https://#{ExampleURL}#:8443/path/_{ProjectName}_Path

https://~{ExampleURL}~:8443/path/_{ProjectName}_Path

https://^{ExampleURL}^:8443/path/_{ProjectName}_Path

https://_{ExampleSubdomain}_.example.com:8443/path/_{ProjectName}_Path
```

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [ ] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
