### PR TITLE
Update AuthorLine to allow for included attributes files

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The following rules have their severity set to `warning`. The AsciiDoc markup re
 | Vale rule | Explanation |
 | --- | --- |
 | AdmonitionTitle | In DITA 1.3, the `<note>` element cannot have a title. Do not assign block titles to [admonitions](https://docs.asciidoctor.org/asciidoc/latest/blocks/admonitions/). |
-| AuthorLine | AsciiDoc interprets the first line that directly follows the document title as an author line. Add an empty line after the document title. |
+| AuthorLine | AsciiDoc interprets the first line that directly follows the document title as an author line. Add an empty line, an attribute declaration, or an include directive after the document title. |
 | BlockTitle | In DITA 1.3, only the `<example>`, `<fig>`, and `<table>` elements can have a title. Do not assign [block titles](https://docs.asciidoctor.org/asciidoc/latest/blocks/add-title/) to other blocks such as paragraphs, lists, or code blocks. |
 | CalloutList | DITA 1.3 does not support [callouts](https://docs.asciidoctor.org/asciidoc/latest/verbatim/callouts/). Rewrite your content to avoid the need for callout numbers and replace the explanation with simple sentences, [an unordered list](https://docs.asciidoctor.org/asciidoc/latest/lists/unordered/), or [a description list](https://docs.asciidoctor.org/asciidoc/latest/lists/description/) as appropriate. |
 | ContentType | Without a clear content type definition, the Vale style cannot reliably report problems related to procedure modules such as `TaskSection` or `TaskExample`. Add the correct `:_mod-docs-content-type:` definition at the top of the file. |

--- a/fixtures/AuthorLine/ignore_includes.adoc
+++ b/fixtures/AuthorLine/ignore_includes.adoc
@@ -1,0 +1,6 @@
+// A document with an include directive after the title:
+= Topic title
+include::shared-attributes.adoc[]
+
+A paragraph.
+

--- a/styles/AsciiDocDITA/AuthorLine.yml
+++ b/styles/AsciiDocDITA/AuthorLine.yml
@@ -13,6 +13,7 @@ script: |
   r_comment_block   := text.re_compile("^/{4,}\\s*$")
   r_document_title  := text.re_compile("^=[ \\t]+\\S.*$")
   r_attribute       := text.re_compile("^:!?\\S[^:]*:")
+  r_include         := text.re_compile("^include::")
 
   document          := text.split(text.trim_suffix(scope, "\n"), "\n")
 
@@ -45,6 +46,8 @@ script: |
       need_empty_line = true
     } else if need_empty_line {
       if r_attribute.match(line) {
+        continue
+      } else if r_include.match(line) {
         continue
       } else if text.trim_space(line) != "" {
         matches = append(matches, {begin: start, end: start + end - 1})

--- a/test/AuthorLine.bats
+++ b/test/AuthorLine.bats
@@ -6,6 +6,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore include directives" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_includes.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Ignore author lines inside of block comments" {
   run run_vale "$BATS_TEST_FILENAME" ignore_comments.adoc
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Fixes issue #134.

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [x] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
