### PR TITLE
Issue#134: Ignore attribute definition files in author lines

### DIFF
--- a/fixtures/AuthorLine/ignore_attribute_files.adoc
+++ b/fixtures/AuthorLine/ignore_attribute_files.adoc
@@ -1,0 +1,5 @@
+// A document with an included attribute definition file:
+= Topic title
+include::_attributes/common-attributes.adoc[]
+
+A paragraph.

--- a/styles/AsciiDocDITA/AuthorLine.yml
+++ b/styles/AsciiDocDITA/AuthorLine.yml
@@ -14,6 +14,12 @@ script: |
   r_document_title  := text.re_compile("^=[ \\t]+\\S.*$")
   r_attribute       := text.re_compile("^:!?\\S[^:]*:")
 
+  // Teams are inconsistent in how they name attribute definition files.
+  // As it is impossible to reliably identify which files only define attributes
+  // without reading their contents, the following is a workaround specifically
+  // for openshift-docs:
+  r_attribute_file  := text.re_compile("^include::_attributes/(?:attributes-[^/]+|[^/]*-?attributes)\\.adoc\\[.*\\][ \\t]*$")
+
   document          := text.split(text.trim_suffix(scope, "\n"), "\n")
 
   in_comment_block  := false
@@ -44,7 +50,7 @@ script: |
       }
       need_empty_line = true
     } else if need_empty_line {
-      if r_attribute.match(line) {
+      if r_attribute.match(line) || r_attribute_file.match(line) {
         continue
       } else if text.trim_space(line) != "" {
         matches = append(matches, {begin: start, end: start + end - 1})

--- a/test/AuthorLine.bats
+++ b/test/AuthorLine.bats
@@ -30,6 +30,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore attribute definition files" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_attribute_files.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Report author lines only once" {
   run run_vale "$BATS_TEST_FILENAME" report_author_line.adoc
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Fixes issue #134. Note that without looking into included files, there is no reliable way for the `AuthorLine` rule to determine whether an `include` directive is problematic or legitimate. As majority of teams are inconsistent in both how they name these attribute definition files or where they place them, attempting to guess these from their file path is unreliable. This is therefore workaround for `openshift-docs`.

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [ ] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
