### PR TITLE
Do not report code that resembles section titles

### DIFF
--- a/fixtures/TaskSection/ignore_code_blocks.adoc
+++ b/fixtures/TaskSection/ignore_code_blocks.adoc
@@ -1,0 +1,13 @@
+// Ignore section headers in code blocks:
+:_module-type: PROCEDURE
+
+= Topic title
+
+A paragraph.
+
+[source,asciidoc]
+----
+== First unsupported section
+
+A paragraph.
+----

--- a/styles/AsciiDocDITA/TaskSection.yml
+++ b/styles/AsciiDocDITA/TaskSection.yml
@@ -9,13 +9,15 @@ script: |
   text              := import("text")
   matches           := []
 
-  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_code_block      := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
   r_comment_block   := text.re_compile("^/{4,}\\s*$")
+  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
   r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:procedure)")
   r_section         := text.re_compile("^={2,}[ \\t]\\S.*$")
 
   document          := text.split(text.trim_suffix(scope, "\n"), "\n")
 
+  in_code_block     := false
   in_comment_block  := false
   is_procedure      := false
   start             := 0
@@ -36,6 +38,17 @@ script: |
     }
     if in_comment_block { continue }
     if r_comment_line.match(line) { continue }
+
+    if r_code_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_code_block {
+        in_code_block = delimiter
+      } else if in_code_block == delimiter {
+        in_code_block = false
+      }
+      continue
+    }
+    if in_code_block { continue }
 
     if r_content_type.match(line) {
       is_procedure = true

--- a/test/TaskSection.bats
+++ b/test/TaskSection.bats
@@ -6,6 +6,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore sections inside of code blocks" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_code_blocks.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Ignore sections in other content types" {
   run run_vale "$BATS_TEST_FILENAME" ignore_other_modules.adoc
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Code blocks sometimes contain lines that resemble section titles. This pull request ensures that the `TaskSection` rule ignores content in code blocks.

### Example AsciiDoc code

```asciidoc
----
========== Warning (Review and fix if needed) ==========
(WARNING) PACKAGE_UPDATES::PACKAGE_NOT_UP_TO_DATE_MESSAGE - Outdated packages detected
----
```

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [ ] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
