### PR TITLE
Issue #143: Do not report IDs without quotes

### DIFF
--- a/fixtures/DocumentId/ignore_no_quotes.adoc
+++ b/fixtures/DocumentId/ignore_no_quotes.adoc
@@ -1,0 +1,6 @@
+// A module with a document id without quotes:
+
+[id=document-id]
+= A document title
+
+A paragraph.

--- a/fixtures/DocumentId/ignore_single_quotes.adoc
+++ b/fixtures/DocumentId/ignore_single_quotes.adoc
@@ -1,0 +1,6 @@
+// A module with a document id in single quotes:
+
+[id='document-id']
+= A document title
+
+A paragraph.

--- a/styles/AsciiDocDITA/DocumentId.yml
+++ b/styles/AsciiDocDITA/DocumentId.yml
@@ -17,7 +17,7 @@ script: |
   r_conditional     := text.re_compile("^(?:ifn?def|ifeval|endif)::\\S*\\[.*\\][ \\t]*$")
   r_document_title  := text.re_compile("^=[ \\t]+[^ \\t].*$")
   r_empty_line      := text.re_compile("^[ \\t]*$")
-  r_id_attribute    := text.re_compile("^\\[(?:id=['\\x22]|#|\\[)[A-Za-z_:{}][A-Za-z0-9_.:{}-]*(?:['\\x22],?[^\\]]*|,[^\\]]*\\]?|\\]?)\\][ \\t]*$")
+  r_id_attribute    := text.re_compile("^\\[(?:id=['\\x22]?|#|\\[)[A-Za-z_:{}][A-Za-z0-9_.:{}-]*(?:['\\x22]?,?[^\\]]*|,[^\\]]*\\]?|\\]?)\\][ \\t]*$")
 
   document          := text.split(text.trim_suffix(scope, "\n"), "\n")
 

--- a/test/DocumentId.bats
+++ b/test/DocumentId.bats
@@ -6,6 +6,18 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore files with document ids in single quotes" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_single_quotes.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore files with document ids without quotes" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_no_quotes.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Ignore files with valid document ids that use shorthand syntax" {
   run run_vale "$BATS_TEST_FILENAME" ignore_shorthand_syntax.adoc
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Fixes issue #143.
 
### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [ ] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
