### PR TITLE
Issue #146: Do not report table rows as invalid procedure titles

### DIFF
--- a/fixtures/TaskTitle/ignore_table_cells.adoc
+++ b/fixtures/TaskTitle/ignore_table_cells.adoc
@@ -1,0 +1,10 @@
+// Table cells with vertical alignment operators:
+:_mod-docs-content-type: PROCEDURE
+
+[cols="2,1"]
+|===
+|First column |Second column
+
+.>|First cell
+|Second cell with a long paragraph so that the previous cell is visibly aligned to the bottom.
+|===

--- a/styles/AsciiDocDITA/TaskTitle.yml
+++ b/styles/AsciiDocDITA/TaskTitle.yml
@@ -22,6 +22,7 @@ script: |
   r_image           := text.re_compile("^image::(?:\\S|\\S.*\\S)\\[.*\\][ \\t]*$")
   r_list_continue   := text.re_compile("^\\+[ \\t]*$")
   r_supported_title := text.re_compile("^\\.{1,2}(?:Prerequisites?|Procedure|Verification|Results?|Troubleshooting|Troubleshooting steps?|Next steps?|Additional resources)[ \\t]*$")
+  r_table_cell      := text.re_compile("^\\.[^ \\t|]+\\|")
   r_table           := text.re_compile("^\\|={3,}[ \\t]*$")
 
   document          := text.split(text.trim_suffix(scope, "\n"), "\n")
@@ -82,7 +83,7 @@ script: |
       continue
     }
 
-    if r_block_title.match(line) && ! r_supported_title.match(line) {
+    if r_block_title.match(line) && ! r_supported_title.match(line) && ! r_table_cell.match(line) {
       if ! is_list_continue {
         expect_block = {begin: start, end: start + end - 1}
       }

--- a/test/TaskTitle.bats
+++ b/test/TaskTitle.bats
@@ -48,6 +48,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore table cells that have similar syntax to block titles" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_table_cells.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Ignore nested block titles" {
   run run_vale "$BATS_TEST_FILENAME" ignore_nested_titles.adoc
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Fixes issue #146.

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [ ] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
