### PR TITLE
Updating AssemblyContents rule to handle _artifacts folder name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Do not commit generated files:
 CHANGELOG.md
+.claude/

--- a/fixtures/AssemblyContents/ignore_attribute_includes.adoc
+++ b/fixtures/AssemblyContents/ignore_attribute_includes.adoc
@@ -9,4 +9,13 @@ include::attributes/attributes.adoc[]
 include::_common/attributes.adoc[]
 include::common/attributes.adoc[]
 
+// Includes from _artifacts directory:
+include::_artifacts/document-attributes-global.adoc[]
+include::artifacts/attributes.adoc[]
+
+// Includes with relative parent path prefix:
+include::../_attributes/attributes.adoc[]
+include::../_artifacts/document-attributes-global.adoc[]
+include::../common/attributes.adoc[]
+
 A paragraph.

--- a/styles/AsciiDocDITA/AssemblyContents.yml
+++ b/styles/AsciiDocDITA/AssemblyContents.yml
@@ -25,7 +25,7 @@ script: |
   // snippet files. As it is impossible to reliably identify these files without
   // reading their contents, the following is a workaround specifically for
   // openshift-docs:
-  r_attribute_file  := text.re_compile("^include::_?(?:attributes|common)/(?:attributes-[^/]+|[^/]*-?attributes)\\.adoc\\[.*\\][ \\t]*$")
+  r_attribute_file  := text.re_compile("^include::(?:\\.\\./)?_?(?:attributes|common|artifacts)/(?:attributes-[^/]+|[^/]*-?attributes[^/]*)\\.adoc\\[.*\\][ \\t]*$")
   r_snippet_file    := text.re_compile("^include::_?snippets/[^/]+\\.adoc\\[.*\\][ \\t]*$")
 
   document          := text.split(text.trim_suffix(scope, "\n"), "\n")


### PR DESCRIPTION
Changes made:

1. `styles/AsciiDocDITA/AssemblyContents.yml` - Updated the r_attribute_file regex:
   - Added `(?:\\.\\./)?` - matches `../` prefix for relative paths from subdirectories (Not personally a fan of this but :shrug:)
   - Added _artifacts/ as a valid attribute directory
   - Changed `[^/]*-?attributes` to `[^/]*-?attributes[^/]*` - matches filenames like document-attributes-global.adoc
2. `fixtures/AssemblyContents/ignore_attribute_includes.adoc` - Added test cases for:
   - `include::_artifacts/document-attributes-global.adoc[]`
   - `include::artifacts/attributes.adoc[]`
   - `include::../_attributes/attributes.adoc[]`
   - `include::../_artifacts/document-attributes-global.adoc[]`
   - `include::../common/attributes.adoc[]`

All 175 tests pass.

🤖 Generated with https://claude.com/claude-code

Signed-off-by: Aidan Reilly <aireilly@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED
