### PR TITLE
Update the ShortDescription rule to correctly report assemblies

### DIFF
--- a/fixtures/ShortDescription/ignore_assembly.adoc
+++ b/fixtures/ShortDescription/ignore_assembly.adoc
@@ -1,5 +1,0 @@
-// An assembly without [role="_abstract"] should be ignored:
-:_mod-docs-content-type: ASSEMBLY
-= Assembly title
-
-A paragraph without abstract.

--- a/fixtures/ShortDescription/ignore_attributes.adoc
+++ b/fixtures/ShortDescription/ignore_attributes.adoc
@@ -1,0 +1,4 @@
+// An attribute definition file without an abstract role definition:
+:_mod-docs-content-type: ATTRIBUTES
+
+:product-name: AsciiDocDITA

--- a/styles/AsciiDocDITA/ShortDescription.yml
+++ b/styles/AsciiDocDITA/ShortDescription.yml
@@ -1,30 +1,26 @@
 # Suggest assigning the [role="_abstract"] attribute list to a paragraph to
-# be used as short description in DITA. Applies to PROCEDURE, CONCEPT,
-# REFERENCE content types, and files without a content type. Does not apply
-# to SNIPPET or ASSEMBLY.
+# be used as short description in DITA.
 ---
 extends: script
-message: 'Assign [role="\_abstract"] to the first paragraph in a concept, procedure, or reference module to use it as <shortdesc> in DITA.'
+message: "Assign [role=\"_abstract\"] to a paragraph to use it as <shortdesc> in DITA."
 level: warning
 link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
 scope: raw
 script: |
   text              := import("text")
-  matches           := []
+  matches           := [{begin: 0, end: 0}]
 
-  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_abstract        := text.re_compile("^\\[role=(?:\"_abstract\"|'_abstract'|_abstract)\\][ \\t]*$")
   r_comment_block   := text.re_compile("^/{4,}\\s*$")
-  r_excluded_type   := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]*(?i:snippet|assembly)[ \\t]*$")
-  r_any_content_type := text.re_compile("^:_(?:mod-docs-content|content|module)-type:")
-  r_abstract        := text.re_compile("^\\[role=(?:\"_abstract\"|'_abstract'|_abstract)\\]")
-  r_title           := text.re_compile("^=[ \\t]+.+$")
+  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:")
+  r_document_title  := text.re_compile("^(?:=[ \\t]+[^ \\t].*|ifn?def::\\S*\\[=[ \\t]+[^ \\t].*\\][ \\t]*)$")
+  r_excluded_type   := text.re_compile("[ \\t]+(?i:snippet|attributes)[ \\t]*$")
 
   document          := text.split(text.trim_suffix(scope, "\n"), "\n")
 
   in_comment_block  := false
-  is_excluded       := false
-  has_abstract      := false
-  title_pos         := false
+  has_title         := false
   start             := 0
   end               := 0
 
@@ -44,21 +40,17 @@ script: |
     if in_comment_block { continue }
     if r_comment_line.match(line) { continue }
 
-    if r_excluded_type.match(line) {
-      is_excluded = true
+    if r_document_title.match(line) {
+      if ! has_title {
+        matches = [{begin: start, end: start + end - 1}]
+        has_title = true
+      }
       continue
     }
 
-    if r_title.match(line) && ! title_pos {
-      title_pos = {begin: start, end: start + end - 1}
-      continue
+    if (r_content_type.match(line) && r_excluded_type.match(line)) ||
+       r_abstract.match(line) {
+      matches = []
+      break
     }
-
-    if r_abstract.match(line) {
-      has_abstract = true
-    }
-  }
-
-  if ! is_excluded && ! has_abstract && title_pos {
-    matches = append(matches, title_pos)
   }

--- a/test/ShortDescription.bats
+++ b/test/ShortDescription.bats
@@ -18,49 +18,49 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore snippet files" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_snippet.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore attribute definition files" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_attributes.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Report files with [role=“_abstract”] or [role=‘_abstract’]" {
   run run_vale "$BATS_TEST_FILENAME" report_curly_quotes.adoc
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 1 ]
-  [ "${lines[0]}" = "report_curly_quotes.adoc:2:1:AsciiDocDITA.ShortDescription:Assign [role=\"\_abstract\"] to the first paragraph in a concept, procedure, or reference module to use it as <shortdesc> in DITA." ]
+  [ "${lines[0]}" = "report_curly_quotes.adoc:2:1:AsciiDocDITA.ShortDescription:Assign [role=\"_abstract\"] to a paragraph to use it as <shortdesc> in DITA." ]
 }
 
 @test "Report files with [role=\"_abstract'] or [role='_abstract]" {
   run run_vale "$BATS_TEST_FILENAME" report_mismatched_quotes.adoc
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 1 ]
-  [ "${lines[0]}" = "report_mismatched_quotes.adoc:2:1:AsciiDocDITA.ShortDescription:Assign [role=\"\_abstract\"] to the first paragraph in a concept, procedure, or reference module to use it as <shortdesc> in DITA." ]
+  [ "${lines[0]}" = "report_mismatched_quotes.adoc:2:1:AsciiDocDITA.ShortDescription:Assign [role=\"_abstract\"] to a paragraph to use it as <shortdesc> in DITA." ]
 }
 
 @test "Report files with abstract in line comments" {
   run run_vale "$BATS_TEST_FILENAME" report_comments.adoc
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 1 ]
-  [ "${lines[0]}" = "report_comments.adoc:4:1:AsciiDocDITA.ShortDescription:Assign [role=\"\_abstract\"] to the first paragraph in a concept, procedure, or reference module to use it as <shortdesc> in DITA." ]
+  [ "${lines[0]}" = "report_comments.adoc:4:1:AsciiDocDITA.ShortDescription:Assign [role=\"_abstract\"] to a paragraph to use it as <shortdesc> in DITA." ]
 }
 
 @test "Report files with no abstracts" {
   run run_vale "$BATS_TEST_FILENAME" report_missing_abstract.adoc
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 1 ]
-  [ "${lines[0]}" = "report_missing_abstract.adoc:3:1:AsciiDocDITA.ShortDescription:Assign [role=\"\_abstract\"] to the first paragraph in a concept, procedure, or reference module to use it as <shortdesc> in DITA." ]
-}
-
-@test "Ignore SNIPPET content type without [role=\"_abstract\"]" {
-  run run_vale "$BATS_TEST_FILENAME" ignore_snippet.adoc
-  [ "$status" -eq 0 ]
-  [ "${lines[0]}" = "" ]
-}
-
-@test "Ignore ASSEMBLY content type without [role=\"_abstract\"]" {
-  run run_vale "$BATS_TEST_FILENAME" ignore_assembly.adoc
-  [ "$status" -eq 0 ]
-  [ "${lines[0]}" = "" ]
+  [ "${lines[0]}" = "report_missing_abstract.adoc:3:1:AsciiDocDITA.ShortDescription:Assign [role=\"_abstract\"] to a paragraph to use it as <shortdesc> in DITA." ]
 }
 
 @test "Report files without content type" {
   run run_vale "$BATS_TEST_FILENAME" report_no_content_type.adoc
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 1 ]
-  [ "${lines[0]}" = "report_no_content_type.adoc:2:1:AsciiDocDITA.ShortDescription:Assign [role=\"\_abstract\"] to the first paragraph in a concept, procedure, or reference module to use it as <shortdesc> in DITA." ]
+  [ "${lines[0]}" = "report_no_content_type.adoc:2:1:AsciiDocDITA.ShortDescription:Assign [role=\"_abstract\"] to a paragraph to use it as <shortdesc> in DITA." ]
 }


### PR DESCRIPTION
Assemblies should not be excluded from the report as their contents is converted to a concept topic. I also simplified the logic for easier future maintenance and reverted to the original message as it was accurate and I intentionally try to keep them as short as possible. In addition to snippets, I also added support for excluding attribute definition files that have the following content type definition:

```asciidoc
:_mod-docs-content-type: ATTRIBUTES
```

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [ ] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
