### PR TITLE
Issue #150: Add a way to exclude attribute definition files

### DIFF
--- a/fixtures/DocumentTitle/ignore_attributes.adoc
+++ b/fixtures/DocumentTitle/ignore_attributes.adoc
@@ -1,0 +1,4 @@
+// An attribute definition file:
+:_mod-docs-content-type: ATTRIBUTES
+
+:product-name: AsciiDocDITA

--- a/styles/AsciiDocDITA/DocumentTitle.yml
+++ b/styles/AsciiDocDITA/DocumentTitle.yml
@@ -13,7 +13,7 @@ script: |
   r_comment_block   := text.re_compile("^/{4,}\\s*$")
   r_comment_line    := text.re_compile("^(//|//[^/].*)$")
   r_document_title  := text.re_compile("^(?:=[ \\t]+[^ \\t].*|ifn?def::\\S*\\[=[ \\t]+[^ \\t].*\\][ \\t]*)$")
-  r_snippet         := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:snippet)[ \\t]*$")
+  r_excluded_type   := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:snippet|attributes)[ \\t]*$")
 
   document          := text.split(text.trim_suffix(scope, "\n"), "\n")
 
@@ -44,7 +44,7 @@ script: |
     }
     if in_code_block { continue }
 
-    if r_snippet.match(line) || r_document_title.match(line) {
+    if r_excluded_type.match(line) || r_document_title.match(line) {
       matches = []
       break
     }

--- a/test/DocumentTitle.bats
+++ b/test/DocumentTitle.bats
@@ -12,6 +12,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore missing document titles in attribute definition files" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_attributes.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Ignore missing document titles in snippet files" {
   run run_vale "$BATS_TEST_FILENAME" ignore_snippets.adoc
   [ "$status" -eq 0 ]


### PR DESCRIPTION
In combination with pull requests #151 and #153, this pull request fixes issue #150 by adding support for excluding attribute definition files that have the following content type definition:

```asciidoc
:_mod-docs-content-type: ATTRIBUTES
```

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [ ] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
