### PR TITLE
Issue #160: Do not report include directives in `TaskStep`

### DIFF
--- a/fixtures/TaskStep/ignore_includes.adoc
+++ b/fixtures/TaskStep/ignore_includes.adoc
@@ -1,4 +1,4 @@
-// A potentially valid include statement in a procedure:
+// Potentially problematic include directives in procedure steps:
 :_mod-docs-content-type: PROCEDURE
 
 .Procedure
@@ -6,5 +6,9 @@
 include::first_step.adoc[]
 
 . A valid step.
+
+include::third_step.adoc[]
+
+. Another valid step.
 
 include::last_step.adoc[]

--- a/styles/AsciiDocDITA/TaskStep.yml
+++ b/styles/AsciiDocDITA/TaskStep.yml
@@ -1,7 +1,7 @@
 # Report content other than steps in procedures.
 ---
 extends: script
-message: "Content other than a single list cannot be mapped to DITA tasks."
+message: "Content other than a single list cannot be mapped to DITA steps."
 level: warning
 link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
 scope: raw

--- a/test/TaskStep.bats
+++ b/test/TaskStep.bats
@@ -64,34 +64,34 @@ load test_helper
   run run_vale "$BATS_TEST_FILENAME" report_non_steps.adoc
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 2 ]
-  [ "${lines[0]}" = "report_non_steps.adoc:6:1:AsciiDocDITA.TaskStep:Content other than a single list cannot be mapped to DITA tasks." ]
-  [ "${lines[1]}" = "report_non_steps.adoc:10:1:AsciiDocDITA.TaskStep:Content other than a single list cannot be mapped to DITA tasks." ]
+  [ "${lines[0]}" = "report_non_steps.adoc:6:1:AsciiDocDITA.TaskStep:Content other than a single list cannot be mapped to DITA steps." ]
+  [ "${lines[1]}" = "report_non_steps.adoc:10:1:AsciiDocDITA.TaskStep:Content other than a single list cannot be mapped to DITA steps." ]
 }
 
 @test "Report content immediately after a code block" {
   run run_vale "$BATS_TEST_FILENAME" report_after_code.adoc
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 1 ]
-  [ "${lines[0]}" = "report_after_code.adoc:12:1:AsciiDocDITA.TaskStep:Content other than a single list cannot be mapped to DITA tasks." ]
+  [ "${lines[0]}" = "report_after_code.adoc:12:1:AsciiDocDITA.TaskStep:Content other than a single list cannot be mapped to DITA steps." ]
 }
 
 @test "Report invalid callouts" {
   run run_vale "$BATS_TEST_FILENAME" report_invalid_callout.adoc
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 1 ]
-  [ "${lines[0]}" = "report_invalid_callout.adoc:12:1:AsciiDocDITA.TaskStep:Content other than a single list cannot be mapped to DITA tasks." ]
+  [ "${lines[0]}" = "report_invalid_callout.adoc:12:1:AsciiDocDITA.TaskStep:Content other than a single list cannot be mapped to DITA steps." ]
 }
 
 @test "Report content after unsupported block titles" {
   run run_vale "$BATS_TEST_FILENAME" report_block_titles.adoc
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 1 ]
-  [ "${lines[0]}" = "report_block_titles.adoc:13:1:AsciiDocDITA.TaskStep:Content other than a single list cannot be mapped to DITA tasks." ]
+  [ "${lines[0]}" = "report_block_titles.adoc:13:1:AsciiDocDITA.TaskStep:Content other than a single list cannot be mapped to DITA steps." ]
 }
 
 @test "Report admonitions after steps" {
   run run_vale "$BATS_TEST_FILENAME" report_admonitions.adoc
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 1 ]
-  [ "${lines[0]}" = "report_admonitions.adoc:9:1:AsciiDocDITA.TaskStep:Content other than a single list cannot be mapped to DITA tasks." ]
+  [ "${lines[0]}" = "report_admonitions.adoc:9:1:AsciiDocDITA.TaskStep:Content other than a single list cannot be mapped to DITA steps." ]
 }


### PR DESCRIPTION
Fixes issue #160. This pull request [excludes `include` directives](https://docs.asciidoctor.org/asciidoc/latest/directives/include/#what-is-an-include-directive) from the `TaskStep` rule as there are many legitimate cases when these includes may resolve correctly. Since `vale` does not and should not read included files to determine whether they are problematic, I opened PR #165 to add a dedicated rule for them.. 

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [ ] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
