### PR TITLE
Fix AuthorLine rule to handle conditional directives

### DIFF
--- a/fixtures/AuthorLine/ignore_conditionals.adoc
+++ b/fixtures/AuthorLine/ignore_conditionals.adoc
@@ -1,0 +1,9 @@
+// A document with conditional directives around the title:
+ifndef::openshift-origin[]
+= Topic title
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+= Alternative title
+endif::openshift-origin[]
+
+A paragraph.

--- a/fixtures/AuthorLine/report_conditionals.adoc
+++ b/fixtures/AuthorLine/report_conditionals.adoc
@@ -1,0 +1,5 @@
+// A document with an author line after a conditional title:
+ifdef::some-attribute[]
+= Topic title
+endif::some-attribute[]
+An author line.

--- a/styles/AsciiDocDITA/AuthorLine.yml
+++ b/styles/AsciiDocDITA/AuthorLine.yml
@@ -11,6 +11,7 @@ script: |
 
   r_comment_line    := text.re_compile("^(//|//[^/].*)$")
   r_comment_block   := text.re_compile("^/{4,}\\s*$")
+  r_conditional     := text.re_compile("^(?:ifn?def|ifeval|endif)::\\S*\\[.*\\][ \\t]*$")
   r_document_title  := text.re_compile("^=[ \\t]+\\S.*$")
   r_attribute       := text.re_compile("^:!?\\S[^:]*:")
 
@@ -42,12 +43,9 @@ script: |
     }
     if in_comment_block { continue }
     if r_comment_line.match(line) { continue }
+    if r_conditional.match(line) { continue }
 
     if r_document_title.match(line) {
-      if need_empty_line {
-        matches = append(matches, {begin: start, end: start + end - 1})
-        break
-      }
       need_empty_line = true
     } else if need_empty_line {
       if r_attribute.match(line) || r_attribute_file.match(line) {

--- a/test/AuthorLine.bats
+++ b/test/AuthorLine.bats
@@ -36,6 +36,19 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore conditional directives around titles" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_conditionals.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Report author lines after conditional titles" {
+  run run_vale "$BATS_TEST_FILENAME" report_conditionals.adoc
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 1 ]
+  [ "${lines[0]}" = "report_conditionals.adoc:5:1:AsciiDocDITA.AuthorLine:Author lines are not supported for topics." ]
+}
+
 @test "Report author lines only once" {
   run run_vale "$BATS_TEST_FILENAME" report_author_line.adoc
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary

The `AuthorLine` rule does not account for AsciiDoc conditional directives (`ifdef`, `ifndef`, `endif`, `ifeval`) appearing around document titles. When a module uses conditional directives to provide alternative titles for different products, the `endif::[]` or second `= Title` line is falsely flagged as an author line.

## Problem

Given a module with conditional titles:

```asciidoc
ifndef::openshift-origin[]
= Installing {sno} manually
endif::openshift-origin[]
ifdef::openshift-origin[]
= Installing {sno-okd} manually
endif::openshift-origin[]
```

The rule flags `endif::openshift-origin[]` (or the second title) as an author line because it doesn't recognize conditional directives as valid content after a document title.

This is inconsistent with other rules (`TaskStep`, `BlockTitle`, `AssemblyContents`, `RelatedLinks`, `TaskTitle`, `TaskExample`, `ExampleBlock`, `DocumentId`) which all include `r_conditional` handling.

## Fix

1. Added `r_conditional` regex (same pattern used by other rules) to skip conditional directives
2. Removed the check that flagged a second document title as an author line — conditional titles legitimately produce multiple title lines in the same file

## Tests

- Added `ignore_conditionals.adoc` fixture — conditional directives around alternative titles (should not flag)
- Added `report_conditionals.adoc` fixture — actual author line after a conditional title (should flag)
- All 190 existing tests continue to pass

---
Generated with [Claude Code](https://claude.com/claude-code)