### PR TITLE
Issue #170: Add support for the IGNORE content type

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ To report problems relevant for specific topic types, the Vale rules recognize t
 
 | Value | Explanation |
 | --- | --- |
+| IGNORE | Identifies the AsciiDoc file as irrelevant for potential conversion to DITA and disables all errors and warnings for it. |
 | ASSEMBLY | Identifies the AsciiDoc file as a modular documentation [assembly](https://redhat-documentation.github.io/modular-docs/#forming-assemblies). This implies that the assembly file follows the modular documentation guidelines and in addition to include directives, it contains a title and an introduction. |
 | ATTRIBUTES | Identifies the AsciiDoc file as an attribute definition file. This implies that the file is only used to provide attribute definitions and does not contain any printable content. |
 | CONCEPT | Identifies the AsciiDoc file as a modular documentation [concept module](https://redhat-documentation.github.io/modular-docs/#creating-concept-modules). |

--- a/fixtures/AdmonitionTitle/ignore_ignored_files.adoc
+++ b/fixtures/AdmonitionTitle/ignore_ignored_files.adoc
@@ -1,0 +1,93 @@
+// A file marked to be ignored:
+:_mod-docs-content-type: IGNORE
+
+// Titles assigned to admonition blocks:
+.An admonition title
+[NOTE]
+====
+A note.
+====
+
+.An admonition title
+[TIP]
+====
+A note.
+====
+
+.An admonition title
+[IMPORTANT]
+====
+A note.
+====
+
+.An admonition title
+[WARNING]
+====
+A note.
+====
+
+.An admonition title
+[CAUTION]
+====
+A note.
+====
+
+// Titles assigned to paragraph admonitions:
+.An admonition title
+NOTE: A note.
+
+.An admonition title
+TIP: A note.
+
+.An admonition title
+IMPORTANT: A note.
+
+.An admonition title
+WARNING: A note.
+
+.An admonition title
+CAUTION: A note.
+
+// An admonition title below the block label:
+[NOTE]
+.An admonition title
+====
+A note.
+====
+
+// An admonition title above the block label separated by empty lines:
+.An admonition title
+
+[NOTE]
+
+====
+A note.
+====
+
+// An admonition title below the block label separated by empty lines:
+[NOTE]
+
+.An admonition title
+
+====
+A note.
+====
+
+// An admonition title after an oddly placed ID:
+[NOTE]
+[id="admonition-id"]
+.An admonition title
+====
+A note.
+====
+
+[NOTE]
+[#admonition-id]
+.An admonition title
+====
+A note.
+====
+
+.An admonition title
+[id="admonition-id"]
+NOTE: A note.

--- a/fixtures/AssemblyContents/ignore_ignored_files.adoc
+++ b/fixtures/AssemblyContents/ignore_ignored_files.adoc
@@ -1,0 +1,8 @@
+// A file marked to be ignored:
+:_mod-docs-content-type: IGNORE
+
+include::first_file.adoc[leveloffset=+1]
+
+An unsupported paragraph.
+
+include::second_file.adoc[leveloffset=+1]

--- a/fixtures/AuthorLine/ignore_ignored_files.adoc
+++ b/fixtures/AuthorLine/ignore_ignored_files.adoc
@@ -1,0 +1,9 @@
+// A file marked to be ignored:
+:_mod-docs-content-type: IGNORE
+
+= Topic title
+An author line.
+
+// Only the document heading can have author lines:
+= Another title
+A paragraph.

--- a/fixtures/BlockTitle/ignore_ignored_files.adoc
+++ b/fixtures/BlockTitle/ignore_ignored_files.adoc
@@ -1,0 +1,18 @@
+// A file marked to be ignored:
+:_mod-docs-content-type: IGNORE
+
+.An unsupported block title
+A paragraph.
+
+.An unsupported block title
+. A list.
+
+.An unsupported block title
+* A list.
+
+.An unsupported block title
+term::
+Definition
+
+term::
+Definition

--- a/fixtures/CalloutList/ignore_ignored_files.adoc
+++ b/fixtures/CalloutList/ignore_ignored_files.adoc
@@ -1,0 +1,19 @@
+// A file marked to be ignored:
+:_mod-docs-content-type: IGNORE
+
+[source,ruby]
+----
+puts "Hello, World!" <1>
+----
+<1> Print "Hello, World!" to standard output.
+
+[source,xml]
+----
+<ph id="project-name">dita-topic</ph> <!--1-->
+----
+<1> A reusable project name definition.
+
+----
+==== <.>
+----
+<.> An example block delimiter.

--- a/fixtures/ConceptLink/ignore_ignored_files.adoc
+++ b/fixtures/ConceptLink/ignore_ignored_files.adoc
@@ -1,0 +1,28 @@
+// A file marked to be ignored:
+:_mod-docs-content-type: IGNORE
+
+= Topic title
+
+* link:/absolute/path/to/file.ext[]
+* link:/absolute/path/to/file.ext#anchor[link text]
+* link:https://example.com[]
+* link:https://example.com[link text]
+* https://example.com
+* https://example.com/page.html
+* https://example.com/page.html#anchor
+* https://example.com[link text]
+* https://example.com/page.html[link text]
+* https://example.com/page.html#anchor[link text]
+
+.Additional resources
+
+* An item.
+
+== Section title
+
+* xref:reference-link[link text]
+* xref:reference-link#anchor[link text]
+* xref:file-name.ext[link text]
+* xref:file-name.ext#anchor[link text]
+* <<anchor>>
+* <<anchor,link text>>

--- a/fixtures/ContentType/ignore_ignored_files.adoc
+++ b/fixtures/ContentType/ignore_ignored_files.adoc
@@ -1,0 +1,6 @@
+// A file marked to be ignored:
+:_mod-docs-content-type: IGNORE
+
+= Topic title
+
+A paragraph.

--- a/fixtures/DiscreteHeading/ignore_ignored_files.adoc
+++ b/fixtures/DiscreteHeading/ignore_ignored_files.adoc
@@ -1,0 +1,13 @@
+// A file marked to be ignored:
+:_mod-docs-content-type: IGNORE
+
+[discrete]
+== A discreate heading
+
+A paragraph.
+
+// A discrete heading with additional parameters:
+[discrete,id="boo"]
+== A discreate heading
+
+A paragraph.

--- a/fixtures/DocumentId/ignore_ignored_files.adoc
+++ b/fixtures/DocumentId/ignore_ignored_files.adoc
@@ -1,0 +1,6 @@
+// A file marked to be ignored:
+:_mod-docs-content-type: IGNORE
+
+= A document title
+
+A paragraph.

--- a/fixtures/DocumentTitle/ignore_ignored_files.adoc
+++ b/fixtures/DocumentTitle/ignore_ignored_files.adoc
@@ -1,0 +1,6 @@
+// A file marked to be ignored:
+:_mod-docs-content-type: IGNORE
+
+== A level 1 section heading
+
+A paragraph.

--- a/fixtures/EntityReference/ignore_ignored_files.adoc
+++ b/fixtures/EntityReference/ignore_ignored_files.adoc
@@ -1,0 +1,6 @@
+// A file marked to be ignored:
+:_mod-docs-content-type: IGNORE
+
+* &hellip;
+* &middot;
+* ...

--- a/fixtures/EquationFormula/ignore_ignored_files.adoc
+++ b/fixtures/EquationFormula/ignore_ignored_files.adoc
@@ -1,0 +1,27 @@
+// A file marked to be ignored:
+:_mod-docs-content-type: IGNORE
+
+:stem:
+
+[stem] 
+++++ 
+sqrt(16) = 4
+++++
+
+[asciimath] 
+++++ 
+sqrt(9) = 3
+++++
+
+// Block STEM content with LaTeX math notation:
+:stem: latexmath
+
+[stem]
+++++
+\alpha = \beta + \gamma
+++++
+
+[latexmath]
+++++
+\alpha = \beta + \gamma
+++++

--- a/fixtures/ExampleBlock/ignore_ignored_files.adoc
+++ b/fixtures/ExampleBlock/ignore_ignored_files.adoc
@@ -1,0 +1,20 @@
+// A file marked to be ignored:
+:_mod-docs-content-type: IGNORE
+
+// An unsupported example in a sidebar block:
+****
+A paragraph.
+
+====
+An unsupported example.
+====
+****
+
+// An unsupported example in a delimited block:
+--
+A paragraph.
+
+====
+An unsupported example.
+====
+--

--- a/fixtures/LineBreak/ignore_ignored_files.adoc
+++ b/fixtures/LineBreak/ignore_ignored_files.adoc
@@ -1,0 +1,36 @@
+// A file marked to be ignored:
+:_mod-docs-content-type: IGNORE
+
+// A hard line break:
+An example +
+hard line break.
+
+// A hard line break:
+/ +
+line break.
+
+// A hard line break attribute:
+:hardbreaks-option:
+
+An example
+hard line break.
+
+// A hard line break using the options attribute:
+[options="hardbreaks"]
+An example
+hard line break
+
+// A hard line break using the options attribute:
+[options='hardbreaks']
+An example
+hard line break
+
+// A hard line break using the options attribute:
+[options=hardbreaks]
+An example
+hard line break
+
+// A hard line break using the shorthand syntax:
+[%hardbreaks]
+An example
+hard line break.

--- a/fixtures/LineBreak/report_line_break.adoc
+++ b/fixtures/LineBreak/report_line_break.adoc
@@ -31,3 +31,7 @@ hard line break
 [%hardbreaks]
 An example
 hard line break.
+
+// A hard line break at the start of a line:
+{empty} +
+An example.

--- a/fixtures/MismatchedId/ignore_ignored_files.adoc
+++ b/fixtures/MismatchedId/ignore_ignored_files.adoc
@@ -1,0 +1,20 @@
+// A file marked to be ignored:
+:_mod-docs-content-type: IGNORE
+
+[id="custom-id']
+== Title
+
+[id='custom-id"]
+== Title
+
+[id="custom-id]
+== Title
+
+[id='custom-id]
+== Title
+
+[id=custom-id"]
+== Title
+
+[id=custom-id']
+== Title

--- a/fixtures/PageBreak/ignore_ignored_files.adoc
+++ b/fixtures/PageBreak/ignore_ignored_files.adoc
@@ -1,0 +1,15 @@
+// A file marked to be ignored:
+:_mod-docs-content-type: IGNORE
+
+A page.
+
+<<<
+
+A page.
+
+<<<<<<
+
+A page.
+
+[%always]
+<<<

--- a/fixtures/RelatedLinks/ignore_ignored_files.adoc
+++ b/fixtures/RelatedLinks/ignore_ignored_files.adoc
@@ -1,0 +1,9 @@
+// A file marked to be ignored:
+:_mod-docs-content-type: IGNORE
+
+.Additional resources
+
+An invalid line.
+
+* An invalid line.
+* An invalid line with a valid link:https://example.com[link].

--- a/fixtures/ShortDescription/ignore_ignored_files.adoc
+++ b/fixtures/ShortDescription/ignore_ignored_files.adoc
@@ -1,0 +1,6 @@
+// A file marked to be ignored:
+:_mod-docs-content-type: IGNORE
+
+= Topic title
+
+A paragraph.

--- a/fixtures/SidebarBlock/ignore_ignored_files.adoc
+++ b/fixtures/SidebarBlock/ignore_ignored_files.adoc
@@ -1,0 +1,16 @@
+// A file marked to be ignored:
+:_mod-docs-content-type: IGNORE
+
+// An explicit sidebar block:
+[sidebar]
+A paragraph.
+
+// A delimited sidebar block:
+****
+A paragraph.
+****
+
+// A delimited sidebar block:
+*******
+A paragraph.
+*******

--- a/fixtures/TableFooter/ignore_ignored_files.adoc
+++ b/fixtures/TableFooter/ignore_ignored_files.adoc
@@ -1,0 +1,51 @@
+// A file marked to be ignored:
+:_mod-docs-content-type: IGNORE
+
+// A table with a footer assigned using the options attribute:
+[options="footer"]
+|===
+|Table header
+
+|First row
+
+|Second row
+
+|Table footer
+|===
+
+// A table with a footer assigned using the options attribute:
+[options='header,footer']
+|===
+|Table header
+
+|First row
+
+|Second row
+
+|Table footer
+|===
+
+// A table with a footer assigned using the options attribute:
+[options=footer]
+|===
+|Table header
+
+|First row
+
+|Second row
+
+|Table footer
+|===
+
+
+// A table with a footer assigned using the shorthand syntax:
+[%header%footer,cols="1"]
+|===
+|Table header
+
+|First row
+
+|Second row
+
+|Table footer
+|===

--- a/fixtures/TaskContents/ignore_ignored_files.adoc
+++ b/fixtures/TaskContents/ignore_ignored_files.adoc
@@ -1,0 +1,4 @@
+// A file marked to be ignored:
+:_mod-docs-content-type: IGNORE
+
+A paragraph.

--- a/fixtures/TaskDuplicate/ignore_ignored_files.adoc
+++ b/fixtures/TaskDuplicate/ignore_ignored_files.adoc
@@ -1,0 +1,54 @@
+// A file marked to be ignored:
+:_mod-docs-content-type: IGNORE
+
+= Topic title
+
+A paragraph.
+
+.Prerequisites
+
+A paragraph.
+
+.Prerequisites
+
+A paragraph.
+
+.Procedure
+
+A paragraph.
+
+.Procedure
+
+A paragraph.
+
+.Verification
+
+A paragraph.
+
+.Verification
+
+A paragraph.
+
+.Troubleshooting
+
+A paragraph.
+
+.Troubleshooting
+
+A paragraph.
+
+.Next steps
+
+A paragraph.
+
+.Next steps
+
+A paragraph.
+
+.Additional resources
+
+A paragraph.
+
+.Additional resources
+
+A paragraph.

--- a/fixtures/TaskExample/ignore_ignored_files.adoc
+++ b/fixtures/TaskExample/ignore_ignored_files.adoc
@@ -1,0 +1,12 @@
+// A file marked to be ignored:
+:_mod-docs-content-type: IGNORE
+
+[example]
+A supported example.
+
+====
+An unsupported example.
+====
+
+[example]
+An unsupported example.

--- a/fixtures/TaskInclude/ignore_ignored_files.adoc
+++ b/fixtures/TaskInclude/ignore_ignored_files.adoc
@@ -1,0 +1,14 @@
+// A file marked to be ignored:
+:_mod-docs-content-type: IGNORE
+
+.Procedure
+
+include::first_step.adoc[]
+
+. A valid step.
+
+include::third_step.adoc[]
+
+. Another valid step.
+
+include::last_step.adoc[]

--- a/fixtures/TaskSection/ignore_ignored_files.adoc
+++ b/fixtures/TaskSection/ignore_ignored_files.adoc
@@ -1,0 +1,19 @@
+// A file marked to be ignored:
+:_mod-docs-content-type: IGNORE
+
+= Topic title
+
+A paragraph.
+
+// Sections are not supported in DITA tasks:
+== First unsupported section
+
+A paragraph.
+
+// Both sections should be reported:
+== Second unsupported section
+
+A paragraph.
+
+// Sections of all levels should be reported:
+=== Third unsupported section

--- a/fixtures/TaskStep/ignore_ignored_files.adoc
+++ b/fixtures/TaskStep/ignore_ignored_files.adoc
@@ -1,0 +1,12 @@
+// A file marked to be ignored:
+:_mod-docs-content-type: IGNORE
+
+.Procedure
+
+An invalid line.
+
+. A valid step.
+
+An invalid line.
+
+. A valid step.

--- a/fixtures/TaskTitle/ignore_ignored_files.adoc
+++ b/fixtures/TaskTitle/ignore_ignored_files.adoc
@@ -1,0 +1,12 @@
+// A file marked to be ignored:
+:_mod-docs-content-type: IGNORE
+
+= Topic title
+
+A paragraph.
+
+.First unsupported title
+
+A paragraph.
+
+.Second unsupported title

--- a/styles/AsciiDocDITA/AdmonitionTitle.yml
+++ b/styles/AsciiDocDITA/AdmonitionTitle.yml
@@ -19,6 +19,7 @@ script: |
   r_comment_line     := text.re_compile("^(//|//[^/].*)$")
   r_empty_line       := text.re_compile("^[ \\t]*$")
   r_id_attribute     := text.re_compile("^\\[(?:id=['\\x22]|#|\\[)[A-Za-z_:{}][A-Za-z0-9_.:{}-]*(?:['\\x22],?[^\\]]*|,[^\\]]*\\]?|\\]?)\\][ \\t]*$")
+  r_ignore_type      := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:ignore)[ \\t]*$")
 
   document           := text.split(text.trim_suffix(scope, "\n"), "\n")
 
@@ -45,6 +46,11 @@ script: |
     if r_comment_line.match(line) { continue }
     if r_empty_line.match(line) { continue }
     if r_id_attribute.match(line) { continue }
+
+    if r_ignore_type.match(line) {
+      matches = []
+      break
+    }
 
     if r_block_title.match(line) {
       if expect_title {

--- a/styles/AsciiDocDITA/AuthorLine.yml
+++ b/styles/AsciiDocDITA/AuthorLine.yml
@@ -18,6 +18,7 @@ script: |
   r_condition_start := text.re_compile("^(?:ifn?def|ifeval)::\\S*\\[.*\\][ \\t]*$")
   r_condition_end   := text.re_compile("^endif::\\S*\\[.*\\][ \\t]*$")
   r_document_title  := text.re_compile("^=[ \\t]+\\S.*$")
+  r_ignore_type     := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:ignore)[ \\t]*$")
 
   // Teams are inconsistent in how they name attribute definition files.
   // As it is impossible to reliably identify which files only define attributes
@@ -51,6 +52,11 @@ script: |
     }
     if in_comment_block { continue }
     if r_comment_line.match(line) { continue }
+
+    if r_ignore_type.match(line) {
+      matches = []
+      break
+    }
 
     if r_condition_start.match(line) {
       condition_count++

--- a/styles/AsciiDocDITA/BlockTitle.yml
+++ b/styles/AsciiDocDITA/BlockTitle.yml
@@ -21,10 +21,11 @@ script: |
   r_comment_block   := text.re_compile("^/{4,}\\s*$")
   r_comment_line    := text.re_compile("^(//|//[^/].*)$")
   r_conditional     := text.re_compile("^(?:ifn?def|ifeval|endif)::\\S*\\[.*\\][ \\t]*$")
-  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:procedure)")
+  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:procedure)[ \\t]*$")
   r_empty_line      := text.re_compile("^[ \\t]*$")
   r_example_block   := text.re_compile("^\\[example\\][ \\t]*$")
   r_example_delim   := text.re_compile("^={4,}[ \\t]*$")
+  r_ignore_type     := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:ignore)[ \\t]*$")
   r_image           := text.re_compile("^image::(?:\\S|\\S.*\\S)\\[.*\\][ \\t]*$")
   r_supported_title := text.re_compile("^\\.{1,2}(?:Prerequisites?|Procedure|Verification|Results?|Troubleshooting|Troubleshooting steps?|Next steps?)[ \\t]*$")
   r_table_cell      := text.re_compile("^\\.[^ \\t|]+\\|")
@@ -66,6 +67,11 @@ script: |
       continue
     }
     if in_code_block { continue }
+
+    if r_ignore_type.match(line) {
+      matches = []
+      break
+    }
 
     if r_content_type.match(line) {
       is_procedure = true

--- a/styles/AsciiDocDITA/CalloutList.yml
+++ b/styles/AsciiDocDITA/CalloutList.yml
@@ -4,10 +4,58 @@
 # for callout numbers and replace the explanation with simple sentences, an
 # unordered list, or a description list as appropriate.
 ---
-extends: existence
+extends: script
 message: "Callouts are not supported in DITA."
 level: warning
 scope: raw
-nonword: true
-tokens:
-  - '^<(?:1|\.)>[ \t]+.*$'
+script: |
+  text              := import("text")
+  matches           := []
+
+  r_callout_list    := text.re_compile("^<(?:1|\\.)>[ \\t]+.*$")
+  r_code_block      := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
+  r_comment_block   := text.re_compile("^/{4,}\\s*$")
+  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_ignore_type     := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:ignore)")
+
+  document          := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  in_code_block     := false
+  in_comment_block  := false
+  start             := 0
+  end               := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_code_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_code_block {
+        in_code_block = delimiter
+      } else if in_code_block == delimiter {
+        in_code_block = false
+      }
+      continue
+    }
+    if in_code_block { continue }
+
+    if r_ignore_type.match(line) {
+      matches = []
+      break
+    } else if r_callout_list.match(line) {
+      matches = append(matches, {begin: start, end: start + end - 1})
+    }
+  }

--- a/styles/AsciiDocDITA/CalloutList.yml
+++ b/styles/AsciiDocDITA/CalloutList.yml
@@ -16,7 +16,7 @@ script: |
   r_code_block      := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
   r_comment_block   := text.re_compile("^/{4,}\\s*$")
   r_comment_line    := text.re_compile("^(//|//[^/].*)$")
-  r_ignore_type     := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:ignore)")
+  r_ignore_type     := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:ignore)[ \\t]*$")
 
   document          := text.split(text.trim_suffix(scope, "\n"), "\n")
 

--- a/styles/AsciiDocDITA/DiscreteHeading.yml
+++ b/styles/AsciiDocDITA/DiscreteHeading.yml
@@ -4,11 +4,59 @@
 # a description list, a level 1 section, or move the content to a separate
 # file.
 ---
-extends: existence
+extends: script
 message: "Discrete headings are not supported in DITA."
 level: warning
 link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
 scope: raw
-nonword: true
-tokens:
-  - '^\[discrete\b[^\n\]]*?\]'
+script: |
+  text              := import("text")
+  matches           := []
+
+  r_code_block      := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
+  r_comment_block   := text.re_compile("^/{4,}\\s*$")
+  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_discrete_attr   := text.re_compile("^\\[discrete\\b.*\\][ \\t]*$")
+  r_ignore_type     := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:ignore)[ \\t]*$")
+
+  document          := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  in_code_block     := false
+  in_comment_block  := false
+  start             := 0
+  end               := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_code_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_code_block {
+        in_code_block = delimiter
+      } else if in_code_block == delimiter {
+        in_code_block = false
+      }
+      continue
+    }
+    if in_code_block { continue }
+
+    if r_ignore_type.match(line) {
+      matches = []
+      break
+    } else if r_discrete_attr.match(line) {
+      matches = append(matches, {begin: start, end: start + end - 1})
+    }
+  }

--- a/styles/AsciiDocDITA/DocumentId.yml
+++ b/styles/AsciiDocDITA/DocumentId.yml
@@ -21,6 +21,7 @@ script: |
   r_document_title  := text.re_compile("^(?:=[ \\t]+[^ \\t].*|ifn?def::\\S*\\[=[ \\t]+[^ \\t].*\\][ \\t]*)$")
   r_empty_line      := text.re_compile("^[ \\t]*$")
   r_id_attribute    := text.re_compile("^\\[(?:id=['\\x22]?|#|\\[)[A-Za-z_:{}][A-Za-z0-9_.:{}-]*(?:['\\x22]?,?[^\\]]*|,[^\\]]*\\]?|\\]?)\\][ \\t]*$")
+  r_ignore_type     := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:ignore)[ \\t]*$")
 
   document          := text.split(text.trim_suffix(scope, "\n"), "\n")
 
@@ -56,6 +57,11 @@ script: |
       continue
     }
     if in_code_block { continue }
+
+    if r_ignore_type.match(line) {
+      matches = []
+      break
+    }
 
     if r_id_attribute.match(line) {
       assigned_id = true

--- a/styles/AsciiDocDITA/DocumentTitle.yml
+++ b/styles/AsciiDocDITA/DocumentTitle.yml
@@ -18,6 +18,7 @@ script: |
   r_comment_line    := text.re_compile("^(//|//[^/].*)$")
   r_document_title  := text.re_compile("^(?:=[ \\t]+[^ \\t].*|ifn?def::\\S*\\[=[ \\t]+[^ \\t].*\\][ \\t]*)$")
   r_excluded_type   := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:snippet|attributes)[ \\t]*$")
+  r_ignore_type     := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:ignore)[ \\t]*$")
 
   document          := text.split(text.trim_suffix(scope, "\n"), "\n")
 
@@ -47,6 +48,11 @@ script: |
       continue
     }
     if in_code_block { continue }
+
+    if r_ignore_type.match(line) {
+      matches = []
+      break
+    }
 
     if r_excluded_type.match(line) || r_document_title.match(line) {
       matches = []

--- a/styles/AsciiDocDITA/EntityReference.yml
+++ b/styles/AsciiDocDITA/EntityReference.yml
@@ -20,6 +20,7 @@ script: |
   r_comment_block    := text.re_compile("^/{4,}\\s*$")
   r_empty_line       := text.re_compile("^[ \\t]*$")
   r_entity_reference := text.re_compile("&[a-zA-Z][a-zA-Z0-9]*;")
+  r_ignore_type      := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:ignore)[ \\t]*$")
   r_list_continue    := text.re_compile("^\\+[ \\t]*$")
   r_sub_disabled     := text.re_compile("-replacements")
   r_sub_replacements := text.re_compile("subs=['\\x22](?:[^'\\x22]*,[ \\t]*|)\\+?(?:replacements|normal)(?:[ \\t]*,[^'\\x22]*|)['\\x22]")
@@ -70,6 +71,11 @@ script: |
         replacements = true
       }
       continue
+    }
+
+    if r_ignore_type.match(line) {
+      matches = []
+      break
     }
 
     if replacements && ! in_code_block {

--- a/styles/AsciiDocDITA/EquationFormula.yml
+++ b/styles/AsciiDocDITA/EquationFormula.yml
@@ -2,13 +2,66 @@
 #
 # The conversion tooling does not implement LaTeX and AsciiMath formulas.
 ---
-extends: existence
+extends: script
 message: "Equations and formulas are not implemented."
 level: warning
 link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
 scope: raw
-nonword: true
-tokens:
-  - '^:stem:(?:|[ \t]+asciimath|[ \t]latexmath)[ \t]*$'
-  - '^\[(?:stem|asciimath|latexmath)\][ \t]*$'
-  - '\b(?:stem|asciimath|latexmath):(?:[a-z,-]+)?\[.*?[^\\]\]'
+script: |
+  text              := import("text")
+  matches           := []
+
+  r_code_block      := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
+  r_comment_block   := text.re_compile("^/{4,}\\s*$")
+  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_ignore_type     := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:ignore)[ \\t]*$")
+  r_stem_attribute  := text.re_compile("^:stem:(?:|[ \\t]+asciimath|[ \\t]+latexmath)[ \\t]*$")
+  r_stem_block      := text.re_compile("\\[(?:stem|asciimath|latexmath)\\b.*\\][ \\t]*$")
+  r_stem_inline     := text.re_compile("\\b(?:stem|asciimath|latexmath):(?:[a-z,-]+)?\\[.*?[^\\\\]\\]")
+
+  document          := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  in_code_block     := false
+  in_comment_block  := false
+  start             := 0
+  end               := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_code_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_code_block {
+        in_code_block = delimiter
+      } else if in_code_block == delimiter {
+        in_code_block = false
+      }
+      continue
+    }
+    if in_code_block { continue }
+
+    if r_ignore_type.match(line) {
+      matches = []
+      break
+    } else if r_stem_attribute.match(line) || r_stem_block.match(line) {
+      matches = append(matches, {begin: start, end: start + end - 1})
+      continue
+    }
+
+    for i, entry in r_stem_inline.find(line, -1) {
+      matches = append(matches, {begin: start + entry[0].begin, end: start + entry[0].end - 1})
+    }
+  }

--- a/styles/AsciiDocDITA/ExampleBlock.yml
+++ b/styles/AsciiDocDITA/ExampleBlock.yml
@@ -23,6 +23,7 @@ script: |
   r_empty_line       := text.re_compile("^[ \\t]*$")
   r_example_block    := text.re_compile("^\\[example\\][ \\t]*$")
   r_example_delim    := text.re_compile("^={4,}[ \\t]*$")
+  r_ignore_type      := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:ignore)[ \\t]*$")
   r_list_continue    := text.re_compile("^\\+[ \\t]*$")
   r_list_item        := text.re_compile("^[ \\t]*[\\*-.]+[ \\t]+\\S.*$")
   r_other_block      := text.re_compile("^(?:\\*{4,}|-{2})[ \\t]*$")
@@ -68,6 +69,11 @@ script: |
       continue
     }
     if in_code_block { continue }
+
+    if r_ignore_type.match(line) {
+      matches = []
+      break
+    }
 
     if r_attribute.match(line) { continue }
     if r_conditional.match(line) { continue }

--- a/styles/AsciiDocDITA/LineBreak.yml
+++ b/styles/AsciiDocDITA/LineBreak.yml
@@ -1,19 +1,64 @@
-# Report that hard line breaks ara not supported.
+# Report that hard line breaks are not supported.
 #
 # DITA 1.3 does not support hard line breaks. Split the text in multiple
 # paragraphs and add the `a` operator inside of tables.
 ---
-extends: existence
+extends: script
 message: "Hard line breaks are not supported in DITA."
 level: warning
 link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
 scope: raw
-nonword: true
-tokens:
-  - '^[^/]{2}.* \+[ \t]*$'
-  - '^. \+[ \t]*$'
-  - '^:hardbreaks-option:(?:|.*?)[ \t]*$'
-  - '^\[[^\]]*%hardbreaks[^\n\]]*?\]'
-  - '^\[[^\]]*options=hardbreaks\b[^\n\]]*?\]'
-  - '^\[[^\]]*options="[^"]*hardbreaks\b[^\n\]]*?\]'
-  - "^\\[[^\\]]*options='[^']*hardbreaks\\b[^\\n\\]]*?\\]"
+script: |
+  text              := import("text")
+  matches           := []
+
+  r_code_block      := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
+  r_comment_block   := text.re_compile("^/{4,}\\s*$")
+  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_ignore_type     := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:ignore)[ \\t]*$")
+  r_break_markup    := text.re_compile("^(?:.|[^/]{2}.*) \\+[ \\t]*$")
+  r_break_option    := text.re_compile("^\\[[^\\]]*(?:%|options=['\\x22]?.*)\\bhardbreaks\\b.*\\][ \\t]*$")
+  r_break_attribute := text.re_compile("^:hardbreaks-option:(?:|[ \\t].*)[ \\t]*$")
+
+  document          := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  in_code_block     := false
+  in_comment_block  := false
+  start             := 0
+  end               := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_code_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_code_block {
+        in_code_block = delimiter
+      } else if in_code_block == delimiter {
+        in_code_block = false
+      }
+      continue
+    }
+    if in_code_block { continue }
+
+    if r_ignore_type.match(line) {
+      matches = []
+      break
+    } else if r_break_markup.match(line) || r_break_option.match(line) ||
+              r_break_attribute.match(line) {
+      matches = append(matches, {begin: start, end: start + end - 1})
+    }
+  }

--- a/styles/AsciiDocDITA/MismatchedId.yml
+++ b/styles/AsciiDocDITA/MismatchedId.yml
@@ -3,14 +3,59 @@
 # The opening and closing quote in a custom ID assignment must match. Make sure
 # you use the same single quote or double quote on both sides of the ID.
 ---
-extends: existence
+extends: script
 message: "The quotes in the ID are mismatched."
 level: error
 link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#errors
 scope: raw
-nonword: true
-tokens:
-  - '^\[id=["\x27][^"\x27]+\]'
-  - '^\[id=[^"\x27]+["\x27]\]'
-  - '^\[id="[^"\x27]+\x27\]'
-  - '^\[id=\x27[^"\x27]+"\]'
+script: |
+  text              := import("text")
+  matches           := []
+
+  r_code_block      := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
+  r_comment_block   := text.re_compile("^/{4,}\\s*$")
+  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_ignore_type     := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:ignore)[ \\t]*$")
+  r_id_attribute    := text.re_compile("^\\[[^\\]]*\\bid=(?:['\\x22][^'\\x22]+|[^'\\x22]+['\\x22]|\\x22[^'\\x22]+'|'[^'\\x22]+\\x22)\\][ \\t]*$")
+
+  document          := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  in_code_block     := false
+  in_comment_block  := false
+  start             := 0
+  end               := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_code_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_code_block {
+        in_code_block = delimiter
+      } else if in_code_block == delimiter {
+        in_code_block = false
+      }
+      continue
+    }
+    if in_code_block { continue }
+
+    if r_ignore_type.match(line) {
+      matches = []
+      break
+    } else if r_id_attribute.match(line) {
+      matches = append(matches, {begin: start, end: start + end - 1})
+    }
+  }

--- a/styles/AsciiDocDITA/NestedSection.yml
+++ b/styles/AsciiDocDITA/NestedSection.yml
@@ -16,7 +16,7 @@ script: |
   r_code_block      := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
   r_comment_block   := text.re_compile("^/{4,}\\s*$")
   r_comment_line    := text.re_compile("^(//|//[^/].*)$")
-  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:ignore)")
+  r_ignore_type     := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:ignore)[ \\t]*$")
   r_nested_section  := text.re_compile("^={3,6}[ \\t]\\S.*$")
 
   document          := text.split(text.trim_suffix(scope, "\n"), "\n")
@@ -53,7 +53,7 @@ script: |
     }
     if in_code_block { continue }
 
-    if r_content_type.match(line) {
+    if r_ignore_type.match(line) {
       matches = []
       break
     } else if r_nested_section.match(line) {

--- a/styles/AsciiDocDITA/PageBreak.yml
+++ b/styles/AsciiDocDITA/PageBreak.yml
@@ -3,11 +3,59 @@
 # DITA 1.3 does not support page breaks. If visual separation of the text is
 # needed, rewrite your content without using a page break.
 ---
-extends: existence
+extends: script
 message: "Page breaks are not supported in DITA."
 level: warning
 link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
 scope: raw
-nonword: true
-tokens:
-  - '^<{3,}[ \t]*$'
+script: |
+  text              := import("text")
+  matches           := []
+
+  r_code_block      := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
+  r_comment_block   := text.re_compile("^/{4,}\\s*$")
+  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_ignore_type     := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:ignore)[ \\t]*$")
+  r_page_break      := text.re_compile("^<{3,}[ \\t]*$")
+
+  document          := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  in_code_block     := false
+  in_comment_block  := false
+  start             := 0
+  end               := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_code_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_code_block {
+        in_code_block = delimiter
+      } else if in_code_block == delimiter {
+        in_code_block = false
+      }
+      continue
+    }
+    if in_code_block { continue }
+
+    if r_ignore_type.match(line) {
+      matches = []
+      break
+    } else if r_page_break.match(line) {
+      matches = append(matches, {begin: start, end: start + end - 1})
+    }
+  }

--- a/styles/AsciiDocDITA/RelatedLinks.yml
+++ b/styles/AsciiDocDITA/RelatedLinks.yml
@@ -21,9 +21,10 @@ script: |
   r_comment_block   := text.re_compile("^/{4,}\\s*$")
   r_comment_line    := text.re_compile("^(//|//[^/].*)$")
   r_conditional     := text.re_compile("^(?:ifn?def|ifeval|endif)::\\S*\\[.*\\][ \\t]*$")
-  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:assembly)")
+  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:assembly)[ \\t]*$")
   r_empty_line      := text.re_compile("^[ \\t]*$")
   r_id_attribute    := text.re_compile("^\\[(?:id=['\\x22]|#|\\[)[A-Za-z_:{}][A-Za-z0-9_.:{}-]*(?:['\\x22],?[^\\]]*|,[^\\]]*\\]?|\\]?)\\][ \\t]*$")
+  r_ignore_type     := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:ignore)[ \\t]*$")
   r_include         := text.re_compile("^include::(?:[^ \\t\\[]|[^[]*[^ \\t\\[])\\[.*\\][ \\t]*$")
   r_inline_link     := text.re_compile("^[ \\t]*[\\*-][ \\t]+(?:|link:|<)(?:|\\+\\+)(?:https?|file|ftp|irc)://[^ \\t\\[\\]]+(?:|\\+\\+)(?:|\\[.*?\\])>?[ \\t]*$")
   r_inline_xref     := text.re_compile("^[ \\t]*[\\*-][ \\t]+<<[A-Za-z0-9/.:{].*?>>[ \\t]*$")
@@ -54,6 +55,11 @@ script: |
     }
     if in_comment_block { continue }
     if r_comment_line.match(line) { continue }
+
+    if r_ignore_type.match(line) {
+      matches = []
+      break
+    }
 
     if r_content_type.match(line) {
       is_assembly = true

--- a/styles/AsciiDocDITA/ShortDescription.yml
+++ b/styles/AsciiDocDITA/ShortDescription.yml
@@ -19,7 +19,7 @@ script: |
   r_comment_line    := text.re_compile("^(//|//[^/].*)$")
   r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:")
   r_document_title  := text.re_compile("^(?:=[ \\t]+[^ \\t].*|ifn?def::\\S*\\[=[ \\t]+[^ \\t].*\\][ \\t]*)$")
-  r_excluded_type   := text.re_compile("[ \\t]+(?i:attributes|map|snippet)[ \\t]*$")
+  r_excluded_type   := text.re_compile("[ \\t]+(?i:attributes|ignore|map|snippet)[ \\t]*$")
 
   document          := text.split(text.trim_suffix(scope, "\n"), "\n")
 

--- a/styles/AsciiDocDITA/SidebarBlock.yml
+++ b/styles/AsciiDocDITA/SidebarBlock.yml
@@ -15,6 +15,7 @@ script: |
   r_code_block      := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
   r_comment_block   := text.re_compile("^/{4,}\\s*$")
   r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_ignore_type     := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:ignore)[ \\t]*$")
   r_sidebar_block   := text.re_compile("^\\[sidebar\\b[^\\]]*?\\][ \\t]*$")
   r_sidebar_delim   := text.re_compile("^\\*{4,}[ \\t]*$")
 
@@ -51,6 +52,11 @@ script: |
       continue
     }
     if in_code_block { continue }
+
+    if r_ignore_type.match(line) {
+      matches = []
+      break
+    }
 
     if r_sidebar_block.match(line) || r_sidebar_delim.match(line) {
       matches = append(matches, {begin: start, end: start + end - 1})

--- a/styles/AsciiDocDITA/TableFooter.yml
+++ b/styles/AsciiDocDITA/TableFooter.yml
@@ -3,14 +3,60 @@
 # DITA 1.3 does not support table footers. Rewrite your content without using
 # a table footer.
 ---
-extends: existence
+extends: script
 message: "Table footers are not supported in DITA."
 level: warning
 link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
 scope: raw
-nonword: true
-tokens:
-  - '^\[[^\]]*%footer[^\n\]]*?\]'
-  - '^\[[^\]]*options=footer\b[^\n\]]*?\]'
-  - '^\[[^\]]*options="[^"]*footer\b[^\n\]]*?\]'
-  - "^\\[[^\\]]*options='[^']*footer\\b[^\\n\\]]*?\\]"
+script: |
+  text              := import("text")
+  matches           := []
+
+  r_code_block      := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
+  r_comment_block   := text.re_compile("^/{4,}\\s*$")
+  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_ignore_type     := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:ignore)[ \\t]*$")
+  r_table_footer    := text.re_compile("^\\[[^\\]]*(?:%|options=['\\x22]?.*)\\bfooter\\b.*\\][ \\t]*$")
+
+  document          := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  in_code_block     := false
+  in_comment_block  := false
+  start             := 0
+  end               := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_code_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_code_block {
+        in_code_block = delimiter
+      } else if in_code_block == delimiter {
+        in_code_block = false
+      }
+      continue
+    }
+    if in_code_block { continue }
+
+    if r_ignore_type.match(line) {
+      matches = []
+      break
+    } else if r_table_footer.match(line) {
+      matches = append(matches, {begin: start, end: start + end - 1})
+      continue
+    }
+  }

--- a/styles/AsciiDocDITA/TableFooter.yml
+++ b/styles/AsciiDocDITA/TableFooter.yml
@@ -57,6 +57,5 @@ script: |
       break
     } else if r_table_footer.match(line) {
       matches = append(matches, {begin: start, end: start + end - 1})
-      continue
     }
   }

--- a/styles/AsciiDocDITA/ThematicBreak.yml
+++ b/styles/AsciiDocDITA/ThematicBreak.yml
@@ -9,20 +9,13 @@ level: warning
 link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
 scope: raw
 script: |
-  // tokens:
-  //   - "^'{3,}[ \\t]*$"
-  //   - '^[*_]{3}[ \t]*$'
-  //   - '^\* \* \*[ \t]*$'
-  //   - '^- - -[ \t]*$'
-  //   - '^_ _ _[ \t]*$'
-
   text              := import("text")
   matches           := []
 
   r_code_block      := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
   r_comment_block   := text.re_compile("^/{4,}\\s*$")
   r_comment_line    := text.re_compile("^(//|//[^/].*)$")
-  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:ignore)")
+  r_ignore_type     := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:ignore)[ \\t]*$")
   r_thematic_break  := text.re_compile("^(?:'{3,}|[*_-]{3}|\\* \\* \\*|_ _ _|- - -)[ \\t]*$")
 
   document          := text.split(text.trim_suffix(scope, "\n"), "\n")
@@ -59,7 +52,7 @@ script: |
     }
     if in_code_block { continue }
 
-    if r_content_type.match(line) {
+    if r_ignore_type.match(line) {
       matches = []
       break
     } else if r_thematic_break.match(line) {

--- a/test/AdmonitionTitle.bats
+++ b/test/AdmonitionTitle.bats
@@ -12,6 +12,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore files withe the IGNORE content type" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_ignored_files.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Report admonition title variations" {
   run run_vale "$BATS_TEST_FILENAME" report_admonition_title.adoc
   [ "$status" -eq 0 ]

--- a/test/AssemblyContents.bats
+++ b/test/AssemblyContents.bats
@@ -48,6 +48,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore files withe the IGNORE content type" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_ignored_files.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Report code blocks between or after includes" {
   run run_vale "$BATS_TEST_FILENAME" report_code_blocks.adoc
   [ "$status" -eq 0 ]

--- a/test/AuthorLine.bats
+++ b/test/AuthorLine.bats
@@ -42,6 +42,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore files withe the IGNORE content type" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_ignored_files.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Report author lines only once" {
   run run_vale "$BATS_TEST_FILENAME" report_author_line.adoc
   [ "$status" -eq 0 ]

--- a/test/BlockTitle.bats
+++ b/test/BlockTitle.bats
@@ -36,6 +36,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore files withe the IGNORE content type" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_ignored_files.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Ignore supported block titles" {
   run run_vale "$BATS_TEST_FILENAME" ignore_block_titles.adoc
   [ "$status" -eq 0 ]

--- a/test/CalloutList.bats
+++ b/test/CalloutList.bats
@@ -12,6 +12,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore files withe the IGNORE content type" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_ignored_files.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Report unsupported callout list variations" {
   run run_vale "$BATS_TEST_FILENAME" report_callout_lists.adoc
   [ "$status" -eq 0 ]

--- a/test/ConceptLink.bats
+++ b/test/ConceptLink.bats
@@ -24,6 +24,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore files withe the IGNORE content type" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_ignored_files.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Report all link variations outside of additional resources" {
   run run_vale "$BATS_TEST_FILENAME" report_invalid_links.adoc
   [ "$status" -eq 0 ]

--- a/test/ContentType.bats
+++ b/test/ContentType.bats
@@ -24,6 +24,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore files withe the IGNORE content type" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_ignored_files.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Report files with _mod-docs-content-type in line comment" {
   run run_vale "$BATS_TEST_FILENAME" report_comments.adoc
   [ "$status" -eq 0 ]

--- a/test/DiscreteHeading.bats
+++ b/test/DiscreteHeading.bats
@@ -6,6 +6,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore files withe the IGNORE content type" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_ignored_files.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Report valid discrete heading variations" {
   run run_vale "$BATS_TEST_FILENAME" report_discrete_heading.adoc
   [ "$status" -eq 0 ]

--- a/test/DocumentId.bats
+++ b/test/DocumentId.bats
@@ -36,6 +36,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore files withe the IGNORE content type" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_ignored_files.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Report document ids that only appear in code blocks" {
   run run_vale "$BATS_TEST_FILENAME" report_code_blocks.adoc
   [ "$status" -eq 0 ]

--- a/test/DocumentTitle.bats
+++ b/test/DocumentTitle.bats
@@ -24,6 +24,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore files withe the IGNORE content type" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_ignored_files.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Report document titles that only appear in code blocks" {
   run run_vale "$BATS_TEST_FILENAME" report_code_blocks.adoc
   [ "$status" -eq 0 ]

--- a/test/EntityReference.bats
+++ b/test/EntityReference.bats
@@ -30,6 +30,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore files withe the IGNORE content type" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_ignored_files.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Report unsupported character entity references" {
   run run_vale "$BATS_TEST_FILENAME" report_entity_references.adoc
   [ "$status" -ne 0 ]

--- a/test/EquationFormula.bats
+++ b/test/EquationFormula.bats
@@ -1,5 +1,11 @@
 load test_helper
 
+@test "Ignore files withe the IGNORE content type" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_ignored_files.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Report block STEM content" {
   run run_vale "$BATS_TEST_FILENAME" report_block_stem.adoc
   [ "$status" -eq 0 ]

--- a/test/ExampleBlock.bats
+++ b/test/ExampleBlock.bats
@@ -24,6 +24,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore files withe the IGNORE content type" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_ignored_files.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Report example blocks in other blocks" {
   run run_vale "$BATS_TEST_FILENAME" report_example_in_block.adoc
   [ "$status" -eq 1 ]

--- a/test/LineBreak.bats
+++ b/test/LineBreak.bats
@@ -15,7 +15,7 @@ load test_helper
 @test "Report valid hard line break variations" {
   run run_vale "$BATS_TEST_FILENAME" report_line_break.adoc
   [ "$status" -eq 0 ]
-  [ "${#lines[@]}" -eq 7 ]
+  [ "${#lines[@]}" -eq 8 ]
   [ "${lines[0]}" = "report_line_break.adoc:2:1:AsciiDocDITA.LineBreak:Hard line breaks are not supported in DITA." ]
   [ "${lines[1]}" = "report_line_break.adoc:6:1:AsciiDocDITA.LineBreak:Hard line breaks are not supported in DITA." ]
   [ "${lines[2]}" = "report_line_break.adoc:10:1:AsciiDocDITA.LineBreak:Hard line breaks are not supported in DITA." ]
@@ -23,4 +23,5 @@ load test_helper
   [ "${lines[4]}" = "report_line_break.adoc:21:1:AsciiDocDITA.LineBreak:Hard line breaks are not supported in DITA." ]
   [ "${lines[5]}" = "report_line_break.adoc:26:1:AsciiDocDITA.LineBreak:Hard line breaks are not supported in DITA." ]
   [ "${lines[6]}" = "report_line_break.adoc:31:1:AsciiDocDITA.LineBreak:Hard line breaks are not supported in DITA." ]
+  [ "${lines[7]}" = "report_line_break.adoc:36:1:AsciiDocDITA.LineBreak:Hard line breaks are not supported in DITA." ]
 }

--- a/test/LineBreak.bats
+++ b/test/LineBreak.bats
@@ -6,6 +6,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore files withe the IGNORE content type" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_ignored_files.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Report valid hard line break variations" {
   run run_vale "$BATS_TEST_FILENAME" report_line_break.adoc
   [ "$status" -eq 0 ]

--- a/test/MismatchedId.bats
+++ b/test/MismatchedId.bats
@@ -6,6 +6,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore files withe the IGNORE content type" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_ignored_files.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Report files with mismatched quotes in IDs" {
   run run_vale "$BATS_TEST_FILENAME" report_mismatched_quotes.adoc
   [ "$status" -ne 0 ]

--- a/test/PageBreak.bats
+++ b/test/PageBreak.bats
@@ -6,6 +6,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore files withe the IGNORE content type" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_ignored_files.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Report valid page break variations" {
   run run_vale "$BATS_TEST_FILENAME" report_page_break.adoc
   [ "$status" -eq 0 ]

--- a/test/RelatedLinks.bats
+++ b/test/RelatedLinks.bats
@@ -42,6 +42,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore files withe the IGNORE content type" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_ignored_files.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Report content other than links in additional resources" {
   run run_vale "$BATS_TEST_FILENAME" report_non_links.adoc
   [ "$status" -eq 0 ]

--- a/test/ShortDescription.bats
+++ b/test/ShortDescription.bats
@@ -36,6 +36,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore files withe the IGNORE content type" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_ignored_files.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Report files with [role=“_abstract”] or [role=‘_abstract’]" {
   run run_vale "$BATS_TEST_FILENAME" report_curly_quotes.adoc
   [ "$status" -eq 0 ]

--- a/test/SidebarBlock.bats
+++ b/test/SidebarBlock.bats
@@ -18,6 +18,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore files withe the IGNORE content type" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_ignored_files.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Report valid sidebar variations" {
   run run_vale "$BATS_TEST_FILENAME" report_sidebar.adoc
   [ "$status" -eq 0 ]

--- a/test/TableFooter.bats
+++ b/test/TableFooter.bats
@@ -6,6 +6,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore files withe the IGNORE content type" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_ignored_files.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Report valid table footer variations" {
   run run_vale "$BATS_TEST_FILENAME" report_table_footers.adoc
   [ "$status" -eq 0 ]

--- a/test/TaskContents.bats
+++ b/test/TaskContents.bats
@@ -12,6 +12,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore files withe the IGNORE content type" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_ignored_files.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Report procedure titles that only appear in code blocks" {
   run run_vale "$BATS_TEST_FILENAME" report_code_blocks.adoc
   [ "$status" -eq 0 ]

--- a/test/TaskDuplicate.bats
+++ b/test/TaskDuplicate.bats
@@ -30,6 +30,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore files withe the IGNORE content type" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_ignored_files.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Report exact duplicates of block titles in procedures" {
   run run_vale "$BATS_TEST_FILENAME" report_same_title.adoc
   [ "$status" -eq 0 ]

--- a/test/TaskExample.bats
+++ b/test/TaskExample.bats
@@ -36,6 +36,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore files withe the IGNORE content type" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_ignored_files.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Report extra example blocks" {
   run run_vale "$BATS_TEST_FILENAME" report_multiple_examples.adoc
   [ "$status" -eq 1 ]

--- a/test/TaskInclude.bats
+++ b/test/TaskInclude.bats
@@ -6,6 +6,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore files withe the IGNORE content type" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_ignored_files.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Report potentially problematic include directives" {
   run run_vale "$BATS_TEST_FILENAME" report_includes.adoc
   [ "$status" -eq 0 ]

--- a/test/TaskSection.bats
+++ b/test/TaskSection.bats
@@ -24,6 +24,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore files withe the IGNORE content type" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_ignored_files.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Report sections in procedures with deprecated _content-type" {
   run run_vale "$BATS_TEST_FILENAME" report_content_type.adoc
   [ "$status" -ne 0 ]

--- a/test/TaskStep.bats
+++ b/test/TaskStep.bats
@@ -60,6 +60,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore files withe the IGNORE content type" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_ignored_files.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Report content other than steps in procedures" {
   run run_vale "$BATS_TEST_FILENAME" report_non_steps.adoc
   [ "$status" -eq 0 ]

--- a/test/TaskTitle.bats
+++ b/test/TaskTitle.bats
@@ -60,6 +60,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore files withe the IGNORE content type" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_ignored_files.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Report block titles in procedures with deprecated _content-type" {
   run run_vale "$BATS_TEST_FILENAME" report_content_type.adoc
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Fixes issue #170. This pull request updates existing rules to recognize and skip any files with the following content type definition:

```asciidoc
:_mod-docs-content-type: IGNORE
```

In addition, it also introduces a new rule, `IgnoredFile`, which can be used to list files intended to be skipped during conversion to DITA.

Note that this is work in progress as implementing this affects every single rule. It also requires rules that currently extend `existence` or `occurrence` to be re-implemented as Tengo scripts.

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [x] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
