### PR TITLE
Correctly recognize uppercase severity

### DIFF
--- a/workflows/dita-main.yml
+++ b/workflows/dita-main.yml
@@ -59,4 +59,4 @@ jobs:
 
       - name: Verify DITA compatibility
         run: |
-          ! grep -he '^\(error\|warning\):' VALE_RESULTS
+          ! grep -hie '^\(error\|warning\):' VALE_RESULTS

--- a/workflows/dita-pull.yml
+++ b/workflows/dita-pull.yml
@@ -60,4 +60,4 @@ jobs:
 
       - name: Verify DITA compatibility
         run: |
-          ! grep -he '^\(error\|warning\):' VALE_RESULTS
+          ! grep -hie '^\(error\|warning\):' VALE_RESULTS


### PR DESCRIPTION
A recent update changed the templates used in the GitHub Actions workflows to print rule severity with uppercase letters. This pull request ensures that the grep commands use case insensitive search when filtering severity levels.

### Implementation checklist

- [ ] The new code has been tested with the latest available version of Vale
- [ ] The new code comes with the corresponding fixtures and test cases
- [ ] The new code comes with the corresponding documentation in the `README.md` file
- [ ] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [ ] The new code passes all tests (run `make test` in the project directory)
