### PR TITLE
Do not report files with the `:_mod-docs-content-type: MAP` content type

### DIFF
--- a/fixtures/ShortDescription/ignore_map.adoc
+++ b/fixtures/ShortDescription/ignore_map.adoc
@@ -1,0 +1,5 @@
+// A map without [role="_abstract"] should be ignored:
+:_mod-docs-content-type: MAP
+= Snippet title
+
+include::another_file.adoc[leveloffset=+1]

--- a/styles/AsciiDocDITA/ShortDescription.yml
+++ b/styles/AsciiDocDITA/ShortDescription.yml
@@ -19,7 +19,7 @@ script: |
   r_comment_line    := text.re_compile("^(//|//[^/].*)$")
   r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:")
   r_document_title  := text.re_compile("^(?:=[ \\t]+[^ \\t].*|ifn?def::\\S*\\[=[ \\t]+[^ \\t].*\\][ \\t]*)$")
-  r_excluded_type   := text.re_compile("[ \\t]+(?i:snippet|attributes)[ \\t]*$")
+  r_excluded_type   := text.re_compile("[ \\t]+(?i:attributes|map|snippet)[ \\t]*$")
 
   document          := text.split(text.trim_suffix(scope, "\n"), "\n")
 

--- a/test/ShortDescription.bats
+++ b/test/ShortDescription.bats
@@ -30,6 +30,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore map files" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_map.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Report files with [role=“_abstract”] or [role=‘_abstract’]" {
   run run_vale "$BATS_TEST_FILENAME" report_curly_quotes.adoc
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Fixes issue #184. As this annotation is currently not intended for wider use and is reserved for a very specific use case, I am not updating the documentation for it at this time. 

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [ ] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
