### PR TITLE
Reimplement the `NestedSection` rule as a script

### DIFF
--- a/fixtures/NestedSection/ignore_code_blocks.adoc
+++ b/fixtures/NestedSection/ignore_code_blocks.adoc
@@ -1,0 +1,13 @@
+// Ignore section headers in code blocks:
+
+[source,asciidoc]
+----
+=== An unsupported section
+
+A paragraph.
+----
+
+....
+=== MD5 Checksums ===
+92245490c552e83baf5f2a2e898d9fff  file.txt
+....

--- a/fixtures/NestedSection/ignore_comments.adoc
+++ b/fixtures/NestedSection/ignore_comments.adoc
@@ -1,2 +1,7 @@
 // A level 2 section:
 //=== An unsupported section
+
+////
+A level 2 section in a block comment:
+=== An unsupported section
+////

--- a/fixtures/NestedSection/ignore_ignored_files.adoc
+++ b/fixtures/NestedSection/ignore_ignored_files.adoc
@@ -1,0 +1,14 @@
+// A file marked to be ignored:
+:_mod-docs-content-type: IGNORE
+
+// A level 2 section:
+=== An unsupported section
+
+// A level 3 section:
+==== An unsupported section
+
+// A level 4 section:
+===== An unsupported section 
+
+// A level 5 section:
+====== An unsupported section

--- a/styles/AsciiDocDITA/NestedSection.yml
+++ b/styles/AsciiDocDITA/NestedSection.yml
@@ -4,11 +4,59 @@
 # the topic, not inside of another <section>. If a level 2 section (===) is
 # needed, create a dedicated topic for it.
 ---
-extends: existence
+extends: script
 message: "Level 2, 3, 4, and 5 sections are not supported in DITA."
 level: error
 link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#errors
 scope: raw
-nonword: true
-tokens:
-  - '^={3,6}[ \t]\S.*$'
+script: |
+  text              := import("text")
+  matches           := []
+
+  r_code_block      := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
+  r_comment_block   := text.re_compile("^/{4,}\\s*$")
+  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:ignore)")
+  r_nested_section  := text.re_compile("^={3,6}[ \\t]\\S.*$")
+
+  document          := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  in_code_block     := false
+  in_comment_block  := false
+  start             := 0
+  end               := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_code_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_code_block {
+        in_code_block = delimiter
+      } else if in_code_block == delimiter {
+        in_code_block = false
+      }
+      continue
+    }
+    if in_code_block { continue }
+
+    if r_content_type.match(line) {
+      matches = []
+      break
+    } else if r_nested_section.match(line) {
+      matches = append(matches, {begin: start, end: start + end - 1})
+    }
+  }

--- a/test/NestedSection.bats
+++ b/test/NestedSection.bats
@@ -1,7 +1,19 @@
 load test_helper
 
-@test "Ignore unsupported sections in single-line comments" {
+@test "Ignore unsupported sections inside of line and block comments" {
   run run_vale "$BATS_TEST_FILENAME" ignore_comments.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore unsupported sections inside of code blocks" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_code_blocks.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore files withe the IGNORE content type" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_ignored_files.adoc
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "" ]
 }


### PR DESCRIPTION
When implemented as a simple existence rule, the `NestedSection` may incorrectly report legitimate lines that appear in comment blocks or code blocks, for example:

```adoc
....
=== MD5 Checksums ===
92245490c552e83baf5f2a2e898d9fff  file.txt
....
```

To avoid false positives like this, this pull request re-implements this rule as a Tengo script and ensures block comments, code blocks, and modules explicitly marked to be ignored are skipped.

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [ ] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
