### PR TITLE
Issue #189: Reimplemented the `ThematicBreak` rule as a script.

### DIFF
--- a/fixtures/ThematicBreak/ignore_code_blocks.adoc
+++ b/fixtures/ThematicBreak/ignore_code_blocks.adoc
@@ -1,0 +1,45 @@
+// Ignore thematic break variations in code blocks:
+
+A page.
+
+....
+'''
+....
+
+A page.
+
+----
+---
+----
+
+A page.
+
+----
+- - -
+----
+
+A page.
+
+----
+___
+----
+
+A page.
+
+----
+_ _ _
+----
+
+A page.
+
+----
+***
+----
+
+A page.
+
+----
+* * *
+----
+
+A page.

--- a/fixtures/ThematicBreak/ignore_comments.adoc
+++ b/fixtures/ThematicBreak/ignore_comments.adoc
@@ -25,3 +25,37 @@
 //* * *
 //
 //A page.
+
+////
+Thematic breaks in a block comment:
+
+A page.
+
+'''
+
+A page.
+
+---
+
+A page.
+
+- - -
+
+A page.
+
+___
+
+A page.
+
+_ _ _
+
+A page.
+
+***
+
+A page.
+
+* * *
+
+A page.
+////

--- a/fixtures/ThematicBreak/ignore_ignored_files.adoc
+++ b/fixtures/ThematicBreak/ignore_ignored_files.adoc
@@ -1,4 +1,5 @@
-// Thematic break variations:
+// A file marked to be ignored:
+:_mod-docs-content-type: IGNORE
 
 A page.
 

--- a/styles/AsciiDocDITA/ThematicBreak.yml
+++ b/styles/AsciiDocDITA/ThematicBreak.yml
@@ -3,15 +3,66 @@
 # DITA 1.3 does not support thematic breaks. If visual separation of the text
 # is needed, rewrite your content without using a thematic break.
 ---
-extends: existence
+extends: script
 message: "Thematic breaks are not supported in DITA."
 level: warning
 link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
 scope: raw
-nonword: true
-tokens:
-  - "^'{3,}[ \\t]*$"
-  - '^[*_]{3}[ \t]*$'
-  - '^\* \* \*[ \t]*$'
-  - '^- - -[ \t]*$'
-  - '^_ _ _[ \t]*$'
+script: |
+  // tokens:
+  //   - "^'{3,}[ \\t]*$"
+  //   - '^[*_]{3}[ \t]*$'
+  //   - '^\* \* \*[ \t]*$'
+  //   - '^- - -[ \t]*$'
+  //   - '^_ _ _[ \t]*$'
+
+  text              := import("text")
+  matches           := []
+
+  r_code_block      := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
+  r_comment_block   := text.re_compile("^/{4,}\\s*$")
+  r_comment_line    := text.re_compile("^(//|//[^/].*)$")
+  r_content_type    := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:ignore)")
+  r_thematic_break  := text.re_compile("^(?:'{3,}|[*_-]{3}|\\* \\* \\*|_ _ _|- - -)[ \\t]*$")
+
+  document          := text.split(text.trim_suffix(scope, "\n"), "\n")
+
+  in_code_block     := false
+  in_comment_block  := false
+  start             := 0
+  end               := 0
+
+  for line in document {
+    start += end
+    end    = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_code_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_code_block {
+        in_code_block = delimiter
+      } else if in_code_block == delimiter {
+        in_code_block = false
+      }
+      continue
+    }
+    if in_code_block { continue }
+
+    if r_content_type.match(line) {
+      matches = []
+      break
+    } else if r_thematic_break.match(line) {
+      matches = append(matches, {begin: start, end: start + end - 1})
+    }
+  }

--- a/test/ThematicBreak.bats
+++ b/test/ThematicBreak.bats
@@ -31,8 +31,8 @@ load test_helper
   [ "${lines[0]}" = "report_thematic_break.adoc:5:1:AsciiDocDITA.ThematicBreak:Thematic breaks are not supported in DITA." ]
   [ "${lines[1]}" = "report_thematic_break.adoc:9:1:AsciiDocDITA.ThematicBreak:Thematic breaks are not supported in DITA." ]
   [ "${lines[2]}" = "report_thematic_break.adoc:13:1:AsciiDocDITA.ThematicBreak:Thematic breaks are not supported in DITA." ]
-  [ "${lines[3]}" = "report_thematic_break.adoc:17:2:AsciiDocDITA.ThematicBreak:Thematic breaks are not supported in DITA." ]
-  [ "${lines[4]}" = "report_thematic_break.adoc:21:2:AsciiDocDITA.ThematicBreak:Thematic breaks are not supported in DITA." ]
+  [ "${lines[3]}" = "report_thematic_break.adoc:17:1:AsciiDocDITA.ThematicBreak:Thematic breaks are not supported in DITA." ]
+  [ "${lines[4]}" = "report_thematic_break.adoc:21:1:AsciiDocDITA.ThematicBreak:Thematic breaks are not supported in DITA." ]
   [ "${lines[5]}" = "report_thematic_break.adoc:25:1:AsciiDocDITA.ThematicBreak:Thematic breaks are not supported in DITA." ]
   [ "${lines[6]}" = "report_thematic_break.adoc:29:1:AsciiDocDITA.ThematicBreak:Thematic breaks are not supported in DITA." ]
 }

--- a/test/ThematicBreak.bats
+++ b/test/ThematicBreak.bats
@@ -1,7 +1,19 @@
 load test_helper
 
-@test "Ignore thematic breaks in single-line comments" {
+@test "Ignore thematic breaks inside of line and block comments" {
   run run_vale "$BATS_TEST_FILENAME" ignore_comments.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore thematic breaks in code blocks" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_code_blocks.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore files withe the IGNORE content type" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_ignored_files.adoc
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "" ]
 }
@@ -15,10 +27,12 @@ load test_helper
 @test "Report valid thematic break variations" {
   run run_vale "$BATS_TEST_FILENAME" report_thematic_break.adoc
   [ "$status" -eq 0 ]
-  [ "${#lines[@]}" -eq 5 ]
-  [ "${lines[0]}" = "report_thematic_break.adoc:9:1:AsciiDocDITA.ThematicBreak:Thematic breaks are not supported in DITA." ]
-  [ "${lines[1]}" = "report_thematic_break.adoc:13:2:AsciiDocDITA.ThematicBreak:Thematic breaks are not supported in DITA." ]
-  [ "${lines[2]}" = "report_thematic_break.adoc:17:2:AsciiDocDITA.ThematicBreak:Thematic breaks are not supported in DITA." ]
-  [ "${lines[3]}" = "report_thematic_break.adoc:21:1:AsciiDocDITA.ThematicBreak:Thematic breaks are not supported in DITA." ]
-  [ "${lines[4]}" = "report_thematic_break.adoc:25:1:AsciiDocDITA.ThematicBreak:Thematic breaks are not supported in DITA." ]
+  [ "${#lines[@]}" -eq 7 ]
+  [ "${lines[0]}" = "report_thematic_break.adoc:5:1:AsciiDocDITA.ThematicBreak:Thematic breaks are not supported in DITA." ]
+  [ "${lines[1]}" = "report_thematic_break.adoc:9:1:AsciiDocDITA.ThematicBreak:Thematic breaks are not supported in DITA." ]
+  [ "${lines[2]}" = "report_thematic_break.adoc:13:1:AsciiDocDITA.ThematicBreak:Thematic breaks are not supported in DITA." ]
+  [ "${lines[3]}" = "report_thematic_break.adoc:17:2:AsciiDocDITA.ThematicBreak:Thematic breaks are not supported in DITA." ]
+  [ "${lines[4]}" = "report_thematic_break.adoc:21:2:AsciiDocDITA.ThematicBreak:Thematic breaks are not supported in DITA." ]
+  [ "${lines[5]}" = "report_thematic_break.adoc:25:1:AsciiDocDITA.ThematicBreak:Thematic breaks are not supported in DITA." ]
+  [ "${lines[6]}" = "report_thematic_break.adoc:29:1:AsciiDocDITA.ThematicBreak:Thematic breaks are not supported in DITA." ]
 }


### PR DESCRIPTION
Fixes issue #189. When implemented as a simple existence rule, the `ThematicBreak` may incorrectly report legitimate lines that appear in comment blocks or code blocks, for example:

```asciidoc
[source,python]
----
string = '''
Multiple
Lines
'''
----
```

To avoid false positives like this, this pull request re-implements this rule as a Tengo script and ensures block comments, code blocks, and modules explicitly marked to be ignored are skipped.


### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [ ] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
