### PR TITLE
Add a rule to report potentially problematic attribute definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ The following rules have their severity set to `suggestion`. These are convenien
 | Vale rule | Explanation |
 | --- | --- |
 | AttributeReference | Lists all [attribute references](https://docs.asciidoctor.org/asciidoc/latest/attributes/reference-attributes/) in the file. Use this information to decide which attribute definitions to supply during conversion. |
+| AttributeDefinition | List all [attribute definitions](https://docs.asciidoctor.org/asciidoc/latest/attributes/built-in-attributes/) in the file that potentially influence the DITA output.  Use this information to anticipate potential problems with the conversion. |
 | ConditionalCode | Lists all `ifdef`, `ifndef`, and `ifeval` [conditional statements](https://docs.asciidoctor.org/asciidoc/latest/directives/conditionals/) in the file. Use this information to decide which attribute definitions to supply during conversion. |
 | IncludeDirective | Lists all [include directives](https://docs.asciidoctor.org/asciidoc/latest/directives/include/) in the file. Use this information to decide if include directives should be processed during conversion. |
 | IntrinsicAttribute | List all [intrinsic attribute references](https://docs.asciidoctor.org/asciidoc/latest/attributes/document-attributes-ref/#intrinsic-attributes) in the file. Use this information to anticipate potential problems with the conversion. |

--- a/fixtures/AttributeDefinition/ignore_attribute_references.adoc
+++ b/fixtures/AttributeDefinition/ignore_attribute_references.adoc
@@ -1,0 +1,3 @@
+// Attribute references of potentially problematic attributes:
+
+{data-uri}

--- a/fixtures/AttributeDefinition/ignore_text.adoc
+++ b/fixtures/AttributeDefinition/ignore_text.adoc
@@ -1,0 +1,5 @@
+// Strings similar to potentially problematic attribute definitions:
+
+:data-uri:A custom value.
+
+A :data-uri: attribute definition.

--- a/fixtures/AttributeDefinition/ignore_unset_attributes.adoc
+++ b/fixtures/AttributeDefinition/ignore_unset_attributes.adoc
@@ -1,0 +1,6 @@
+// Unset attributes:
+
+:!data-uri:
+:data-uri!:
+
+A paragraph.

--- a/fixtures/AttributeDefinition/report_problematic_attributes.adoc
+++ b/fixtures/AttributeDefinition/report_problematic_attributes.adoc
@@ -1,0 +1,6 @@
+// Potentially problematic attribute definitions:
+
+:data-uri:
+:data-uri: A custom value
+
+A paragraph.

--- a/fixtures/AttributeDefinition/vale.ini
+++ b/fixtures/AttributeDefinition/vale.ini
@@ -1,0 +1,5 @@
+StylesPath = ../../styles/
+MinAlertLevel = suggestion
+
+[*.adoc]
+AsciiDocDITA.AttributeDefinition = YES

--- a/styles/AsciiDocDITA/AttributeDefinition.yml
+++ b/styles/AsciiDocDITA/AttributeDefinition.yml
@@ -1,0 +1,14 @@
+# Report potentially problematic attribute definitions.
+#
+# List all attribute definitions that may unexpectedly influence the DITA
+# output. Use this information to anticipate potential problems with the
+# conversion.
+---
+extends: existence
+message: "%s"
+level: suggestion
+link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#suggestions
+scope: raw
+nonword: true
+tokens:
+  - '^:data-uri:(?:[ \t].*|)$'

--- a/test/AttributeDefinition.bats
+++ b/test/AttributeDefinition.bats
@@ -1,0 +1,27 @@
+load test_helper
+
+@test "Ignore references to potentially problematic attributes" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_attribute_references.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore unset attributes" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_unset_attributes.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore text resembling problematic attribute definitions" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_text.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Report potentially problematic attribute definitions" {
+  run run_vale "$BATS_TEST_FILENAME" report_problematic_attributes.adoc
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 2 ]
+  [ "${lines[0]}" = "report_problematic_attributes.adoc:3:1:AsciiDocDITA.AttributeDefinition::data-uri:" ]
+  [ "${lines[1]}" = "report_problematic_attributes.adoc:4:1:AsciiDocDITA.AttributeDefinition::data-uri: A custom value" ]
+}


### PR DESCRIPTION
Asciidoctor documents a number of attributes that alter the way the content is converted. Notably, it supports `:data-uri:` which when set, causes Asciidoctor to embed images in the output DITA file as base64 strings. To provide visibility into these, this pull request adds a new rule, `AttributeDefinition`, which reports these potentially problematic attributes.

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [ ] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
