### PR TITLE
Issue #192: Improve snippet recognition in `AssemblyContents`

### DIFF
--- a/fixtures/AssemblyContents/ignore_attribute_includes.adoc
+++ b/fixtures/AssemblyContents/ignore_attribute_includes.adoc
@@ -17,4 +17,8 @@ include::_attributes.adoc[]
 include::../attributes.adoc[]
 include::../../attributes.adoc[]
 
+include::{docdir}/_attributes/attributes.adoc[]
+include::{docdir}/common/attributes.adoc[]
+include::{docdir}/attributes.adoc[]
+
 A paragraph.

--- a/fixtures/AssemblyContents/ignore_snippet_includes.adoc
+++ b/fixtures/AssemblyContents/ignore_snippet_includes.adoc
@@ -5,5 +5,13 @@ include::_snippets/snip_snippet-file.adoc[]
 include::snippets/common-snippets.adoc[]
 include::../snippets/snippet-file.adoc[]
 include::../../snippets/snippet-file.adoc[]
+include::{docdir}/snippets/snip_file.adoc[]
+
+include::attributes/snip-file.adoc[]
+include::artifacts/snip_file.adoc[]
+include::common/snip_file.adoc[]
+include::../attributes/snip_file.adoc[]
+include::../../attributes/snip_file.adoc[]
+include::{docdir}/attributes/snip-file.adoc[]
 
 A paragraph.

--- a/fixtures/AssemblyContents/ignore_snippet_includes.adoc
+++ b/fixtures/AssemblyContents/ignore_snippet_includes.adoc
@@ -3,6 +3,7 @@
 
 include::_snippets/snip_snippet-file.adoc[]
 include::snippets/common-snippets.adoc[]
+include::snippets/arbitrary-file-name.adoc[]
 include::../snippets/snippet-file.adoc[]
 include::../../snippets/snippet-file.adoc[]
 include::{docdir}/snippets/snip_file.adoc[]

--- a/fixtures/AssemblyContents/ignore_snippet_includes.adoc
+++ b/fixtures/AssemblyContents/ignore_snippet_includes.adoc
@@ -7,11 +7,10 @@ include::../snippets/snippet-file.adoc[]
 include::../../snippets/snippet-file.adoc[]
 include::{docdir}/snippets/snip_file.adoc[]
 
-include::attributes/snip-file.adoc[]
-include::artifacts/snip_file.adoc[]
+include::artifacts/snip-file.adoc[]
 include::common/snip_file.adoc[]
-include::../attributes/snip_file.adoc[]
-include::../../attributes/snip_file.adoc[]
-include::{docdir}/attributes/snip-file.adoc[]
+include::../artifacts/snip_file.adoc[]
+include::../../artifacts/snip_file.adoc[]
+include::{docdir}/artifacts/snip-file.adoc[]
 
 A paragraph.

--- a/styles/AsciiDocDITA/AssemblyContents.yml
+++ b/styles/AsciiDocDITA/AssemblyContents.yml
@@ -30,7 +30,7 @@ script: |
   // reading their contents, the following is a workaround specifically for
   // openshift-docs:
   r_attribute_file  := text.re_compile("^include::(?:\\{docdir\\}/)?(?:\\.\\./)*_?(?:attributes|(?:attributes|common|artifacts)/(?:attributes-[^/]+|[^/]*-?attributes[^/]*))\\.adoc\\[.*\\][ \\t]*$")
-  r_snippet_file    := text.re_compile("^include::(?:\\{docdir\\}/)?(?:\\.\\./)*_?(?:snippets/[^/]+|(?:attributes|common|artifacts)/snip[_-][^/]*)\\.adoc\\[.*\\][ \\t]*$")
+  r_snippet_file    := text.re_compile("^include::(?:\\{docdir\\}/)?(?:\\.\\./)*_?(?:snippets/[^/]+|(?:common|artifacts)/snip[_-][^/]*)\\.adoc\\[.*\\][ \\t]*$")
 
   document          := text.split(text.trim_suffix(scope, "\n"), "\n")
 

--- a/styles/AsciiDocDITA/AssemblyContents.yml
+++ b/styles/AsciiDocDITA/AssemblyContents.yml
@@ -29,8 +29,8 @@ script: |
   // snippet files. As it is impossible to reliably identify these files without
   // reading their contents, the following is a workaround specifically for
   // openshift-docs:
-  r_attribute_file  := text.re_compile("^include::(?:\\.\\./)*_?(?:attributes|(?:attributes|common|artifacts)/(?:attributes-[^/]+|[^/]*-?attributes[^/]*))\\.adoc\\[.*\\][ \\t]*$")
-  r_snippet_file    := text.re_compile("^include::(?:\\.\\./)*_?snippets/[^/]+\\.adoc\\[.*\\][ \\t]*$")
+  r_attribute_file  := text.re_compile("^include::(?:\\{docdir\\}/)?(?:\\.\\./)*_?(?:attributes|(?:attributes|common|artifacts)/(?:attributes-[^/]+|[^/]*-?attributes[^/]*))\\.adoc\\[.*\\][ \\t]*$")
+  r_snippet_file    := text.re_compile("^include::(?:\\{docdir\\}/)?(?:\\.\\./)*_?(?:snippets/[^/]+|(?:attributes|common|artifacts)/snip[_-][^/]*)\\.adoc\\[.*\\][ \\t]*$")
 
   document          := text.split(text.trim_suffix(scope, "\n"), "\n")
 


### PR DESCRIPTION
Fixes issue #192.

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [ ] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
