### PR TITLE
Do not report escaped links

### DIFF
--- a/fixtures/ConceptLink/ignore_escaped_links.adoc
+++ b/fixtures/ConceptLink/ignore_escaped_links.adoc
@@ -21,3 +21,9 @@
 * value=https://example.com
 * value-https://example.com
 * value,https://example.com
+
+* https://
+* file://
+* `https://`
+* `file://`
+* **https://**

--- a/fixtures/ConceptLink/ignore_escaped_links.adoc
+++ b/fixtures/ConceptLink/ignore_escaped_links.adoc
@@ -16,5 +16,8 @@
 * https://_{ExampleURL}_:8443/path/_{ProjectName}_Path
 
 * `+https://example.com/+`
-* ++https://example.com/++
+* +https://example.com/+
+* "https://example.com"
 * value=https://example.com
+* value-https://example.com
+* value,https://example.com

--- a/fixtures/ConceptLink/ignore_escaped_links.adoc
+++ b/fixtures/ConceptLink/ignore_escaped_links.adoc
@@ -14,3 +14,7 @@
 * https://^example.com^/page.html#anchor
 * https://__example.com__/page.html#anchor
 * https://_{ExampleURL}_:8443/path/_{ProjectName}_Path
+
+* `+https://example.com/+`
+* ++https://example.com/++
+* value=https://example.com

--- a/fixtures/ConceptLink/ignore_escaped_links.adoc
+++ b/fixtures/ConceptLink/ignore_escaped_links.adoc
@@ -27,3 +27,6 @@
 * `https://`
 * `file://`
 * **https://**
+* (https://)
+* [https://]
+* <https://>

--- a/fixtures/ConceptLink/report_invalid_links.adoc
+++ b/fixtures/ConceptLink/report_invalid_links.adoc
@@ -13,6 +13,13 @@
 * https://example.com[link text]
 * https://example.com/page.html[link text]
 * https://example.com/page.html#anchor[link text]
+* _https://example.com/_
+* *https://example.com/*
+* `https://example.com/`
+* #https://example.com/#
+* ~https://example.com/~
+* ^https://example.com/^
+* __https://example.com/__
 
 .Additional resources
 

--- a/fixtures/ConceptLink/report_invalid_links.adoc
+++ b/fixtures/ConceptLink/report_invalid_links.adoc
@@ -19,6 +19,10 @@
 * #https://example.com/#
 * ~https://example.com/~
 * ^https://example.com/^
+* (https://example.com)
+* [https://example.com]
+* <https://example.com>
+
 
 .Additional resources
 

--- a/fixtures/ConceptLink/report_invalid_links.adoc
+++ b/fixtures/ConceptLink/report_invalid_links.adoc
@@ -19,7 +19,6 @@
 * #https://example.com/#
 * ~https://example.com/~
 * ^https://example.com/^
-* __https://example.com/__
 
 .Additional resources
 

--- a/styles/AsciiDocDITA/ConceptLink.yml
+++ b/styles/AsciiDocDITA/ConceptLink.yml
@@ -14,7 +14,7 @@ script: |
   matches           := []
 
   r_add_resources   := text.re_compile("^(?:={2,}[ \\t]+|\\.{1,2})Additional resources[ \\t]*$")
-  r_allowed_char    := text.re_compile("[_*`#~^ \\t]")
+  r_allowed_char    := text.re_compile("[_*`#~^ \\t()<>\\[\\]]")
   r_any_title       := text.re_compile("^(?:={2,}[ \\t]+|\\.{1,2})[^ \\t.].*$")
   r_code_block      := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
   r_comment_block   := text.re_compile("^/{4,}\\s*$")
@@ -25,7 +25,7 @@ script: |
   r_inline_xref     := text.re_compile("<<[A-Za-z0-9/.:{].*?>>")
   r_link_macro      := text.re_compile("(?:link|mailto):(?:|[^: \\t\\[][^: \\t\\[]*)\\[.*?\\]")
   r_xref_macro      := text.re_compile("xref:[A-Za-z0-9/.:{].*?\\[.*?\\]")
-  r_uri_scheme      := text.re_compile("^(?:https?|file|ftp|irc)://[_*`#~^]*$")
+  r_uri_scheme      := text.re_compile("^[_*`#~^()<>\\[\\]]*(?:https?|file|ftp|irc)://[_*`#~^()<>\\[\\]]*$")
 
   document          := text.split(text.trim_suffix(scope, "\n"), "\n")
 

--- a/styles/AsciiDocDITA/ConceptLink.yml
+++ b/styles/AsciiDocDITA/ConceptLink.yml
@@ -25,6 +25,7 @@ script: |
   r_inline_xref     := text.re_compile("<<[A-Za-z0-9/.:{].*?>>")
   r_link_macro      := text.re_compile("(?:link|mailto):(?:|[^: \\t\\[][^: \\t\\[]*)\\[.*?\\]")
   r_xref_macro      := text.re_compile("xref:[A-Za-z0-9/.:{].*?\\[.*?\\]")
+  r_uri_scheme      := text.re_compile("^(?:https?|file|ftp|irc)://[_*`#~^]*$")
 
   document          := text.split(text.trim_suffix(scope, "\n"), "\n")
 
@@ -42,7 +43,7 @@ script: |
       if (link.begin > 0) && ! r_allowed_char.match(text.substr(line, link.begin - 1, link.begin)) {
         continue
       }
-      if r_domain_markup.match(link.text) {
+      if r_domain_markup.match(link.text) || r_uri_scheme.match(link.text) {
         continue
       }
 

--- a/styles/AsciiDocDITA/ConceptLink.yml
+++ b/styles/AsciiDocDITA/ConceptLink.yml
@@ -14,6 +14,7 @@ script: |
   matches           := []
 
   r_add_resources   := text.re_compile("^(?:={2,}[ \\t]+|\\.{1,2})Additional resources[ \\t]*$")
+  r_allowed_char    := text.re_compile("[_*`#~^ \\t]")
   r_any_title       := text.re_compile("^(?:={2,}[ \\t]+|\\.{1,2})[^ \\t.].*$")
   r_code_block      := text.re_compile("^(?:\\.{4,}|-{4,})[ \\t]*$")
   r_comment_block   := text.re_compile("^/{4,}\\s*$")
@@ -38,7 +39,7 @@ script: |
     for i, entry in regex.find(line, -1) {
       link := entry[0]
 
-      if (link.begin > 0) && text.has_prefix(text.substr(line, link.begin - 1, link.begin), '\\') {
+      if (link.begin > 0) && ! r_allowed_char.match(text.substr(line, link.begin - 1, link.begin)) {
         continue
       }
       if r_domain_markup.match(link.text) {

--- a/test/ConceptLink.bats
+++ b/test/ConceptLink.bats
@@ -33,7 +33,7 @@ load test_helper
 @test "Report all link variations outside of additional resources" {
   run run_vale "$BATS_TEST_FILENAME" report_invalid_links.adoc
   [ "$status" -eq 0 ]
-  [ "${#lines[@]}" -eq 23 ]
+  [ "${#lines[@]}" -eq 22 ]
   [ "${lines[0]}" = "report_invalid_links.adoc:6:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
   [ "${lines[1]}" = "report_invalid_links.adoc:7:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
   [ "${lines[2]}" = "report_invalid_links.adoc:8:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
@@ -50,13 +50,12 @@ load test_helper
   [ "${lines[13]}" = "report_invalid_links.adoc:19:4:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
   [ "${lines[14]}" = "report_invalid_links.adoc:20:4:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
   [ "${lines[15]}" = "report_invalid_links.adoc:21:4:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
-  [ "${lines[16]}" = "report_invalid_links.adoc:22:5:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
+  [ "${lines[16]}" = "report_invalid_links.adoc:29:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
   [ "${lines[17]}" = "report_invalid_links.adoc:30:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
   [ "${lines[18]}" = "report_invalid_links.adoc:31:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
   [ "${lines[19]}" = "report_invalid_links.adoc:32:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
   [ "${lines[20]}" = "report_invalid_links.adoc:33:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
   [ "${lines[21]}" = "report_invalid_links.adoc:34:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
-  [ "${lines[22]}" = "report_invalid_links.adoc:35:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
 
 }
 

--- a/test/ConceptLink.bats
+++ b/test/ConceptLink.bats
@@ -33,7 +33,7 @@ load test_helper
 @test "Report all link variations outside of additional resources" {
   run run_vale "$BATS_TEST_FILENAME" report_invalid_links.adoc
   [ "$status" -eq 0 ]
-  [ "${#lines[@]}" -eq 16 ]
+  [ "${#lines[@]}" -eq 23 ]
   [ "${lines[0]}" = "report_invalid_links.adoc:6:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
   [ "${lines[1]}" = "report_invalid_links.adoc:7:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
   [ "${lines[2]}" = "report_invalid_links.adoc:8:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
@@ -44,12 +44,20 @@ load test_helper
   [ "${lines[7]}" = "report_invalid_links.adoc:13:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
   [ "${lines[8]}" = "report_invalid_links.adoc:14:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
   [ "${lines[9]}" = "report_invalid_links.adoc:15:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
-  [ "${lines[10]}" = "report_invalid_links.adoc:23:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
-  [ "${lines[11]}" = "report_invalid_links.adoc:24:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
-  [ "${lines[12]}" = "report_invalid_links.adoc:25:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
-  [ "${lines[13]}" = "report_invalid_links.adoc:26:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
-  [ "${lines[14]}" = "report_invalid_links.adoc:27:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
-  [ "${lines[15]}" = "report_invalid_links.adoc:28:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
+  [ "${lines[10]}" = "report_invalid_links.adoc:16:4:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
+  [ "${lines[11]}" = "report_invalid_links.adoc:17:4:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
+  [ "${lines[12]}" = "report_invalid_links.adoc:18:4:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
+  [ "${lines[13]}" = "report_invalid_links.adoc:19:4:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
+  [ "${lines[14]}" = "report_invalid_links.adoc:20:4:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
+  [ "${lines[15]}" = "report_invalid_links.adoc:21:4:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
+  [ "${lines[16]}" = "report_invalid_links.adoc:22:5:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
+  [ "${lines[17]}" = "report_invalid_links.adoc:30:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
+  [ "${lines[18]}" = "report_invalid_links.adoc:31:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
+  [ "${lines[19]}" = "report_invalid_links.adoc:32:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
+  [ "${lines[20]}" = "report_invalid_links.adoc:33:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
+  [ "${lines[21]}" = "report_invalid_links.adoc:34:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
+  [ "${lines[22]}" = "report_invalid_links.adoc:35:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
+
 }
 
 @test "Report links with attribute references" {

--- a/test/ConceptLink.bats
+++ b/test/ConceptLink.bats
@@ -33,7 +33,7 @@ load test_helper
 @test "Report all link variations outside of additional resources" {
   run run_vale "$BATS_TEST_FILENAME" report_invalid_links.adoc
   [ "$status" -eq 0 ]
-  [ "${#lines[@]}" -eq 22 ]
+  [ "${#lines[@]}" -eq 25 ]
   [ "${lines[0]}" = "report_invalid_links.adoc:6:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
   [ "${lines[1]}" = "report_invalid_links.adoc:7:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
   [ "${lines[2]}" = "report_invalid_links.adoc:8:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
@@ -50,12 +50,15 @@ load test_helper
   [ "${lines[13]}" = "report_invalid_links.adoc:19:4:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
   [ "${lines[14]}" = "report_invalid_links.adoc:20:4:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
   [ "${lines[15]}" = "report_invalid_links.adoc:21:4:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
-  [ "${lines[16]}" = "report_invalid_links.adoc:29:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
-  [ "${lines[17]}" = "report_invalid_links.adoc:30:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
-  [ "${lines[18]}" = "report_invalid_links.adoc:31:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
-  [ "${lines[19]}" = "report_invalid_links.adoc:32:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
-  [ "${lines[20]}" = "report_invalid_links.adoc:33:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
-  [ "${lines[21]}" = "report_invalid_links.adoc:34:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
+  [ "${lines[16]}" = "report_invalid_links.adoc:22:4:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
+  [ "${lines[17]}" = "report_invalid_links.adoc:23:4:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
+  [ "${lines[18]}" = "report_invalid_links.adoc:24:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
+  [ "${lines[19]}" = "report_invalid_links.adoc:33:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
+  [ "${lines[20]}" = "report_invalid_links.adoc:34:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
+  [ "${lines[21]}" = "report_invalid_links.adoc:35:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
+  [ "${lines[22]}" = "report_invalid_links.adoc:36:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
+  [ "${lines[23]}" = "report_invalid_links.adoc:37:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
+  [ "${lines[24]}" = "report_invalid_links.adoc:38:3:AsciiDocDITA.ConceptLink:Move all links and cross references to Additional resources." ]
 
 }
 


### PR DESCRIPTION
  This pull request improves the recognition of links that are escaped by their surrounding text:

```console
$ cat <<-EOF | asciidoctor - -o - | xmllint - --html --xpath 'count(//a)'
> * +https://example.com+
> * "https://example.com"
> * value=https://example.com
> * value,https://example.com
> EOF
0
```

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [ ] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
