### PR TITLE
Refactor the `DocumentTitle` rule

### DIFF
--- a/styles/AsciiDocDITA/DocumentTitle.yml
+++ b/styles/AsciiDocDITA/DocumentTitle.yml
@@ -17,8 +17,7 @@ script: |
   r_comment_block   := text.re_compile("^/{4,}\\s*$")
   r_comment_line    := text.re_compile("^(//|//[^/].*)$")
   r_document_title  := text.re_compile("^(?:=[ \\t]+[^ \\t].*|ifn?def::\\S*\\[=[ \\t]+[^ \\t].*\\][ \\t]*)$")
-  r_excluded_type   := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:snippet|attributes)[ \\t]*$")
-  r_ignore_type     := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:ignore)[ \\t]*$")
+  r_excluded_type   := text.re_compile("^:_(?:mod-docs-content|content|module)-type:[ \\t]+(?i:attributes|ignore|snippet)[ \\t]*$")
 
   document          := text.split(text.trim_suffix(scope, "\n"), "\n")
 
@@ -48,11 +47,6 @@ script: |
       continue
     }
     if in_code_block { continue }
-
-    if r_ignore_type.match(line) {
-      matches = []
-      break
-    }
 
     if r_excluded_type.match(line) || r_document_title.match(line) {
       matches = []


### PR DESCRIPTION
This pull request does not alter the behavior of the `DocumentTitle` rule in any way, just simplifies the code for easier maintenance.

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [ ] The new code comes with the corresponding fixtures and test cases
- [ ] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
