### PR TITLE
Update `TaskStep` to report the `start` attibute in steps

### DIFF
--- a/fixtures/TaskStep/ignore_list_start.adoc
+++ b/fixtures/TaskStep/ignore_list_start.adoc
@@ -1,0 +1,8 @@
+// A list start in a procedure:
+:_mod-docs-content-type: PROCEDURE
+
+.Procedure
+
+[start=2]
+. A valid step.
+. A valid step.

--- a/fixtures/TaskStep/report_list_restart.adoc
+++ b/fixtures/TaskStep/report_list_restart.adoc
@@ -1,0 +1,9 @@
+// A list restart in a procedure:
+:_mod-docs-content-type: PROCEDURE
+
+.Procedure
+
+. A valid step.
+
+[start=2]
+. A valid step.

--- a/styles/AsciiDocDITA/TaskStep.yml
+++ b/styles/AsciiDocDITA/TaskStep.yml
@@ -26,6 +26,7 @@ script: |
   r_example_delim   := text.re_compile("^={4,}[ \\t]*$")
   r_include         := text.re_compile("^include::(?:[^ \\t\\[]|[^[]*[^ \\t\\[])\\[.*\\][ \\t]*$")
   r_list_continue   := text.re_compile("^\\+[ \\t]*$")
+  r_list_restart    := text.re_compile("^\\[start=[0-9]+\\][ \\t]*$")
   r_other_block     := text.re_compile("^(?:\\.{4,}|-{4,}|={4,}|-{2}|\\|={3,})[ \\t]*$")
   r_procedure       := text.re_compile("^(?:={2,}[ \\t]+|\\.{1,2})Procedure[ \\t]*$")
   r_step            := text.re_compile("^[ \\t]*[\\*-.]+[ \\t]+\\S.*$")
@@ -67,7 +68,9 @@ script: |
     if r_conditional.match(line) { continue }
     if r_include.match(line) { continue }
     if r_attribute.match(line) { continue }
-    if r_attribute_list.match(line) && ! r_admonition.match(line) {
+    if r_attribute_list.match(line) &&
+       ! r_admonition.match(line) &&
+       ! r_list_restart.match(line) {
       continue
     }
 
@@ -122,6 +125,7 @@ script: |
     }
 
     if in_step { continue }
+    if ! in_list && r_list_restart.match(line) { continue }
 
     if r_example_delim.match(line) { break }
 

--- a/test/TaskStep.bats
+++ b/test/TaskStep.bats
@@ -60,6 +60,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore the start attribute before steps" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_list_start.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Ignore files withe the IGNORE content type" {
   run run_vale "$BATS_TEST_FILENAME" ignore_ignored_files.adoc
   [ "$status" -eq 0 ]
@@ -100,4 +106,11 @@ load test_helper
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 1 ]
   [ "${lines[0]}" = "report_admonitions.adoc:9:1:AsciiDocDITA.TaskStep:Content other than a single list cannot be mapped to DITA steps." ]
+}
+
+@test "Report the start attribute in steps" {
+  run run_vale "$BATS_TEST_FILENAME" report_list_restart.adoc
+  [ "$status" -eq 0 ]
+  [ "${#lines[@]}" -eq 1 ]
+  [ "${lines[0]}" = "report_list_restart.adoc:8:1:AsciiDocDITA.TaskStep:Content other than a single list cannot be mapped to DITA steps." ]
 }


### PR DESCRIPTION
AsciiDoc supports the `start` attribute to allow users to [decide the starting numeral](https://docs.asciidoctor.org/asciidoc/latest/lists/ordered/) of ordered lists. When used in the middle of the list, despite the appearance, this attribute starts a new list, which the official documentation explicitly warns about:

```asciidoc
. First step.

[start=2]
. Second step.
```

Notice this creates two ordered lists instead of one:

```console
$ asciidoctor -so - file.adoc | xmllint - --html --xpath 'count(//ol)'
2
```

This pull request updates `TaskStep` to issue a warning when the `start` attribute is present in the middle of procedure steps:

```console
$ vale test.adoc

 test.adoc
 8:1  warning  Content other than a single list cannot be mapped to DITA steps.  AsciiDocDITA.TaskStep

✖ 0 errors, 1 warning and 0 suggestions in 1 file.
```

### Implementation checklist

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [ ] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
