### PR TITLE
OSDOCS-17289: Improvements to error messages to improve clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ To set up a workflow to validate only files modified in a pull request:
     vale .
     ```
 
-    Note that on larger documentation projects, running `vale` like this may be slow or even fail with an error if your project uses symbolic links to other directories. To work around this problem, run `vale` in multiple parallel processes simultaneously, for example: 
+    Note that on larger documentation projects, running `vale` like this may be slow or even fail with an error if your project uses symbolic links to other directories. To work around this problem, run `vale` in multiple parallel processes simultaneously, for example:
 
     ```console
     find . -type f -name '*.adoc' | xargs -n 1 -P 14 vale --output line
@@ -113,7 +113,7 @@ The following rules have their severity set to `error`. The AsciiDoc markup repo
 | MismatchedId | The opening and closing quote in [a custom ID assignment](https://docs.asciidoctor.org/asciidoc/latest/attributes/id/#block-assignment) must match. Make sure you use the same single quote or double quote on both sides of the ID. |
 | NestedSection | DITA 1.3 allows the `<section>` element to appear only within the main body of the topic, not inside of another `<section>`. If [a level 2 section](https://docs.asciidoctor.org/asciidoc/latest/sections/titles-and-levels/) (`===`) is needed, create a dedicated topic for it. |
 | TaskExample | DITA 1.3 allows only one `<example>` element in a task topic. If multiple examples are needed, combine them in a single [example block](https://docs.asciidoctor.org/asciidoc/latest/blocks/example-blocks/). |
-| TaskSection | DITA 1.3 does not allow [sections](https://docs.asciidoctor.org/asciidoc/latest/sections/titles-and-levels/) in a task topic. If a section is needed, move it to a separate file. |
+| TaskSection | DITA 1.3 does not allow [sections (==)](https://docs.asciidoctor.org/asciidoc/latest/sections/titles-and-levels/) in a task topic. If a section is needed, move it to a separate file. |
 
 ### Warnings
 

--- a/styles/AsciiDocDITA/DocumentId.yml
+++ b/styles/AsciiDocDITA/DocumentId.yml
@@ -4,7 +4,7 @@
 # title.
 ---
 extends: script
-message: "The document id assigned to the level 0 heading is missing."
+message: "The document ID assigned to the level 0 (=) heading is missing."
 level: warning
 link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
 scope: raw

--- a/styles/AsciiDocDITA/DocumentTitle.yml
+++ b/styles/AsciiDocDITA/DocumentTitle.yml
@@ -5,7 +5,7 @@
 # at the top of the file to mark it as a snippet.
 ---
 extends: script
-message: "The document title (a level 0 heading) is missing."
+message: "The document title (=) is missing."
 level: warning
 link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#warnings
 scope: raw

--- a/styles/AsciiDocDITA/ExampleBlock.yml
+++ b/styles/AsciiDocDITA/ExampleBlock.yml
@@ -5,7 +5,7 @@
 # part of lists.
 ---
 extends: script
-message: "Examples can not be inside of other blocks in DITA."
+message: "Example blocks can not be inside of other blocks in DITA."
 level: error
 link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#errors
 scope: raw

--- a/styles/AsciiDocDITA/NestedSection.yml
+++ b/styles/AsciiDocDITA/NestedSection.yml
@@ -5,7 +5,7 @@
 # needed, create a dedicated topic for it.
 ---
 extends: script
-message: "Level 2, 3, 4, and 5 sections are not supported in DITA."
+message: "Level 2, 3, 4, and 5 sections (=== and deeper) are not supported in DITA."
 level: error
 link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#errors
 scope: raw

--- a/styles/AsciiDocDITA/TaskSection.yml
+++ b/styles/AsciiDocDITA/TaskSection.yml
@@ -4,7 +4,7 @@
 # move it to a separate file.
 ---
 extends: script
-message: "Sections are not allowed in DITA tasks."
+message: "Sections (==) are not allowed in DITA tasks."
 level: error
 link: https://github.com/jhradilek/asciidoctor-dita-vale/blob/main/README.md#errors
 scope: raw

--- a/test/DocumentId.bats
+++ b/test/DocumentId.bats
@@ -46,33 +46,33 @@ load test_helper
   run run_vale "$BATS_TEST_FILENAME" report_code_blocks.adoc
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 1 ]
-  [ "${lines[0]}" = "report_code_blocks.adoc:8:1:AsciiDocDITA.DocumentId:The document id assigned to the level 0 heading is missing." ]
+  [ "${lines[0]}" = "report_code_blocks.adoc:8:1:AsciiDocDITA.DocumentId:The document ID assigned to the level 0 (=) heading is missing." ]
 }
 
 @test "Report document ids that only appear in comments" {
   run run_vale "$BATS_TEST_FILENAME" report_comments.adoc
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 1 ]
-  [ "${lines[0]}" = "report_comments.adoc:8:1:AsciiDocDITA.DocumentId:The document id assigned to the level 0 heading is missing." ]
+  [ "${lines[0]}" = "report_comments.adoc:8:1:AsciiDocDITA.DocumentId:The document ID assigned to the level 0 (=) heading is missing." ]
 }
 
 @test "Report ids followed by invalid blocks" {
   run run_vale "$BATS_TEST_FILENAME" report_invalid_blocks.adoc
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 1 ]
-  [ "${lines[0]}" = "report_invalid_blocks.adoc:6:1:AsciiDocDITA.DocumentId:The document id assigned to the level 0 heading is missing." ]
+  [ "${lines[0]}" = "report_invalid_blocks.adoc:6:1:AsciiDocDITA.DocumentId:The document ID assigned to the level 0 (=) heading is missing." ]
 }
 
 @test "Report missing document ids" {
   run run_vale "$BATS_TEST_FILENAME" report_missing_id.adoc
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 1 ]
-  [ "${lines[0]}" = "report_missing_id.adoc:3:1:AsciiDocDITA.DocumentId:The document id assigned to the level 0 heading is missing." ]
+  [ "${lines[0]}" = "report_missing_id.adoc:3:1:AsciiDocDITA.DocumentId:The document ID assigned to the level 0 (=) heading is missing." ]
 }
 
 @test "Report missing document ids for conditional titles" {
   run run_vale "$BATS_TEST_FILENAME" report_conditional_title.adoc
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 1 ]
-  [ "${lines[0]}" = "report_conditional_title.adoc:3:1:AsciiDocDITA.DocumentId:The document id assigned to the level 0 heading is missing." ]
+  [ "${lines[0]}" = "report_conditional_title.adoc:3:1:AsciiDocDITA.DocumentId:The document ID assigned to the level 0 (=) heading is missing." ]
 }

--- a/test/DocumentTitle.bats
+++ b/test/DocumentTitle.bats
@@ -34,19 +34,19 @@ load test_helper
   run run_vale "$BATS_TEST_FILENAME" report_code_blocks.adoc
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 1 ]
-  [ "${lines[0]}" = "report_code_blocks.adoc:1:1:AsciiDocDITA.DocumentTitle:The document title (a level 0 heading) is missing." ]
+  [ "${lines[0]}" = "report_code_blocks.adoc:1:1:AsciiDocDITA.DocumentTitle:The document title (=) is missing." ]
 }
 
 @test "Report document titles that only appear in comments" {
   run run_vale "$BATS_TEST_FILENAME" report_comments.adoc
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 1 ]
-  [ "${lines[0]}" = "report_comments.adoc:1:1:AsciiDocDITA.DocumentTitle:The document title (a level 0 heading) is missing." ]
+  [ "${lines[0]}" = "report_comments.adoc:1:1:AsciiDocDITA.DocumentTitle:The document title (=) is missing." ]
 }
 
 @test "Report missing document titles" {
   run run_vale "$BATS_TEST_FILENAME" report_missing_title.adoc
   [ "$status" -eq 0 ]
   [ "${#lines[@]}" -eq 1 ]
-  [ "${lines[0]}" = "report_missing_title.adoc:1:1:AsciiDocDITA.DocumentTitle:The document title (a level 0 heading) is missing." ]
+  [ "${lines[0]}" = "report_missing_title.adoc:1:1:AsciiDocDITA.DocumentTitle:The document title (=) is missing." ]
 }

--- a/test/ExampleBlock.bats
+++ b/test/ExampleBlock.bats
@@ -34,23 +34,23 @@ load test_helper
   run run_vale "$BATS_TEST_FILENAME" report_example_in_block.adoc
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 2 ]
-  [ "${lines[0]}" = "report_example_in_block.adoc:5:1:AsciiDocDITA.ExampleBlock:Examples can not be inside of other blocks in DITA." ]
-  [ "${lines[1]}" = "report_example_in_block.adoc:14:1:AsciiDocDITA.ExampleBlock:Examples can not be inside of other blocks in DITA." ]
+  [ "${lines[0]}" = "report_example_in_block.adoc:5:1:AsciiDocDITA.ExampleBlock:Example blocks can not be inside of other blocks in DITA." ]
+  [ "${lines[1]}" = "report_example_in_block.adoc:14:1:AsciiDocDITA.ExampleBlock:Example blocks can not be inside of other blocks in DITA." ]
 }
 
 @test "Report example blocks in list items" {
   run run_vale "$BATS_TEST_FILENAME" report_example_in_list.adoc
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 3 ]
-  [ "${lines[0]}" = "report_example_in_list.adoc:5:1:AsciiDocDITA.ExampleBlock:Examples can not be inside of other blocks in DITA." ]
-  [ "${lines[1]}" = "report_example_in_list.adoc:12:1:AsciiDocDITA.ExampleBlock:Examples can not be inside of other blocks in DITA." ]
-  [ "${lines[2]}" = "report_example_in_list.adoc:19:1:AsciiDocDITA.ExampleBlock:Examples can not be inside of other blocks in DITA." ]
+  [ "${lines[0]}" = "report_example_in_list.adoc:5:1:AsciiDocDITA.ExampleBlock:Example blocks can not be inside of other blocks in DITA." ]
+  [ "${lines[1]}" = "report_example_in_list.adoc:12:1:AsciiDocDITA.ExampleBlock:Example blocks can not be inside of other blocks in DITA." ]
+  [ "${lines[2]}" = "report_example_in_list.adoc:19:1:AsciiDocDITA.ExampleBlock:Example blocks can not be inside of other blocks in DITA." ]
 }
 
 @test "Report example blocks in sections" {
   run run_vale "$BATS_TEST_FILENAME" report_example_in_section.adoc
   [ "$status" -eq 1 ]
   [ "${#lines[@]}" -eq 2 ]
-  [ "${lines[0]}" = "report_example_in_section.adoc:4:1:AsciiDocDITA.ExampleBlock:Examples can not be inside of other blocks in DITA." ]
-  [ "${lines[1]}" = "report_example_in_section.adoc:7:1:AsciiDocDITA.ExampleBlock:Examples can not be inside of other blocks in DITA." ]
+  [ "${lines[0]}" = "report_example_in_section.adoc:4:1:AsciiDocDITA.ExampleBlock:Example blocks can not be inside of other blocks in DITA." ]
+  [ "${lines[1]}" = "report_example_in_section.adoc:7:1:AsciiDocDITA.ExampleBlock:Example blocks can not be inside of other blocks in DITA." ]
 }

--- a/test/NestedSection.bats
+++ b/test/NestedSection.bats
@@ -34,8 +34,8 @@ load test_helper
   run run_vale "$BATS_TEST_FILENAME" report_nested_section.adoc
   [ "$status" -ne 0 ]
   [ "${#lines[@]}" -eq 4 ]
-  [ "${lines[0]}" = "report_nested_section.adoc:2:1:AsciiDocDITA.NestedSection:Level 2, 3, 4, and 5 sections are not supported in DITA." ]
-  [ "${lines[1]}" = "report_nested_section.adoc:5:1:AsciiDocDITA.NestedSection:Level 2, 3, 4, and 5 sections are not supported in DITA." ]
-  [ "${lines[2]}" = "report_nested_section.adoc:8:1:AsciiDocDITA.NestedSection:Level 2, 3, 4, and 5 sections are not supported in DITA." ]
-  [ "${lines[3]}" = "report_nested_section.adoc:11:1:AsciiDocDITA.NestedSection:Level 2, 3, 4, and 5 sections are not supported in DITA." ]
+  [ "${lines[0]}" = "report_nested_section.adoc:2:1:AsciiDocDITA.NestedSection:Level 2, 3, 4, and 5 sections (=== and deeper) are not supported in DITA." ]
+  [ "${lines[1]}" = "report_nested_section.adoc:5:1:AsciiDocDITA.NestedSection:Level 2, 3, 4, and 5 sections (=== and deeper) are not supported in DITA." ]
+  [ "${lines[2]}" = "report_nested_section.adoc:8:1:AsciiDocDITA.NestedSection:Level 2, 3, 4, and 5 sections (=== and deeper) are not supported in DITA." ]
+  [ "${lines[3]}" = "report_nested_section.adoc:11:1:AsciiDocDITA.NestedSection:Level 2, 3, 4, and 5 sections (=== and deeper) are not supported in DITA." ]
 }

--- a/test/TaskSection.bats
+++ b/test/TaskSection.bats
@@ -34,21 +34,21 @@ load test_helper
   run run_vale "$BATS_TEST_FILENAME" report_content_type.adoc
   [ "$status" -ne 0 ]
   [ "${#lines[@]}" -eq 1 ]
-  [ "${lines[0]}" = "report_content_type.adoc:9:1:AsciiDocDITA.TaskSection:Sections are not allowed in DITA tasks." ]
+  [ "${lines[0]}" = "report_content_type.adoc:9:1:AsciiDocDITA.TaskSection:Sections (==) are not allowed in DITA tasks." ]
 }
 
 @test "Report sections in procedures with deprecated _module-type" {
   run run_vale "$BATS_TEST_FILENAME" report_module_type.adoc
   [ "$status" -ne 0 ]
   [ "${#lines[@]}" -eq 1 ]
-  [ "${lines[0]}" = "report_module_type.adoc:9:1:AsciiDocDITA.TaskSection:Sections are not allowed in DITA tasks." ]
+  [ "${lines[0]}" = "report_module_type.adoc:9:1:AsciiDocDITA.TaskSection:Sections (==) are not allowed in DITA tasks." ]
 }
 
 @test "Report sections in procedure modules" {
   run run_vale "$BATS_TEST_FILENAME" report_sections.adoc
   [ "$status" -ne 0 ]
   [ "${#lines[@]}" -eq 3 ]
-  [ "${lines[0]}" = "report_sections.adoc:9:1:AsciiDocDITA.TaskSection:Sections are not allowed in DITA tasks." ]
-  [ "${lines[1]}" = "report_sections.adoc:14:1:AsciiDocDITA.TaskSection:Sections are not allowed in DITA tasks." ]
-  [ "${lines[2]}" = "report_sections.adoc:19:1:AsciiDocDITA.TaskSection:Sections are not allowed in DITA tasks." ]
+  [ "${lines[0]}" = "report_sections.adoc:9:1:AsciiDocDITA.TaskSection:Sections (==) are not allowed in DITA tasks." ]
+  [ "${lines[1]}" = "report_sections.adoc:14:1:AsciiDocDITA.TaskSection:Sections (==) are not allowed in DITA tasks." ]
+  [ "${lines[2]}" = "report_sections.adoc:19:1:AsciiDocDITA.TaskSection:Sections (==) are not allowed in DITA tasks." ]
 }


### PR DESCRIPTION
This update attempts to clarify a few of the error messages that some writers seem to be stumbling on. See https://redhat.atlassian.net/browse/OSDOCS-17289 for more information.

### Implementation checklist

_This updates existing strings only._

- [x] The new code has been tested with the latest available version of Vale
- [x] The new code comes with the corresponding fixtures and test cases
- [x] The new code comes with the corresponding documentation in the `README.md` file
- [x] The new code passes `yamllint` validation (run `make validate` in the project directory)
- [x] The new code passes all tests (run `make test` in the project directory)
